### PR TITLE
Add packed-radix segmented-sort foundation (2/7)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1003,6 +1003,7 @@ add_library(
   src/sort/is_sorted.cu
   src/sort/rank.cu
   src/sort/segmented_sort.cu
+  src/sort/segmented_sort_fixed_width.cu
   src/sort/segmented_top_k.cu
   src/sort/sort.cu
   src/sort/sort_column.cu

--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -21,15 +21,13 @@
 
 // Benchmark for cudf::lists::sort_lists on a LIST<numeric> column -- the operation Spark array_sort
 // lowers to. The type axis spans the integral, floating-point, and decimal128 fixed-width paths.
-// The segmented sort routes in a single split today: a no-null integral or non-DECIMAL128
-// fixed-point column goes to CUB DeviceSegmentedSort while the average list size stays under 100 or
-// the total row count under 2^18; everything else (float, double, DECIMAL128, or any nulls) takes
-// the generic fallback, a lexicographic comparator sort over a prepended segment-id column. The
-// shape axes bracket that boundary: max_list_size 4 and 32 keep eligible types on the CUB path at
-// both row counts; 256 (average ~128) stays on it only at 100k rows (total-size arm) and falls back
-// at 1M rows. null_frequency 0.1 forces every type onto the fallback; 0 exercises the no-null
-// routing. The order and null_order axes complete the sort-parameter matrix: the CUB path honors
-// order (its gate excludes nulls) and the fallback honors both.
+// For an explicit ascending / nulls-after sort, an integral or floating-point column now takes the
+// global packed-radix path when it carries nulls or its average list size reaches 100; the short
+// no-null remainder keeps CUB DeviceSegmentedSort (integral) or the comparator fallback (floating
+// point). DECIMAL128 and every other (order, null_order) combination keep the base routing: CUB
+// for eligible no-null integrals, otherwise the lexicographic comparator over a prepended
+// segment-id column. The shape axes bracket those boundaries; cells outside ascending /
+// nulls-after measure the base paths.
 template <typename Type>
 void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
 {
@@ -84,10 +82,9 @@ void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
     mem_stats_logger.peak_memory_usage(), "peak_memory_usage", "peak_memory_usage");
 }
 
-// Chrono is not on the type axis: timestamps are neither integral nor fixed-point to the fast-path
-// gate, so they take the same comparator fallback the float/double cells already measure.
-// decimal128 is likewise excluded from the CUB path (128-bit storage exceeds its fast-sort
-// support) and needs its own type-string mapping.
+// Chrono is not on the type axis: its packed key is byte-identical to the int32/int64 rep it
+// extracts to, so those cells already measure it. decimal128 stays on the comparator fallback at
+// this stage and needs its own type-string mapping.
 NVBENCH_DECLARE_TYPE_STRINGS(numeric::decimal128, "decimal128", "decimal128");
 
 NVBENCH_BENCH_TYPES(
@@ -96,13 +93,13 @@ NVBENCH_BENCH_TYPES(
     nvbench::type_list<std::int32_t, std::int64_t, float, double, numeric::decimal128>))
   .set_name("sort_list_of_numbers")
   .add_int64_axis("num_rows", {100'000, 1'000'000})
-  // 4 and 32 keep eligible no-null types on the CUB fast path (average under its 100 cutoff); 256
-  // (average ~128) stays on it only at 100k rows via the total-size arm and falls back at 1M.
+  // 4 and 32 keep no-null cells below the packed-radix average gate (100); 256 (average ~128)
+  // crosses it, routing eligible ascending / nulls-after cells to the packed radix.
   .add_int64_axis("max_list_size", {4, 32, 256})
-  // No-null vs a realistic null rate; any nulls disqualify the CUB fast path, so 0.1 forces every
-  // type onto the comparator fallback.
+  // No-null vs a realistic null rate; nulls route eligible ascending / nulls-after cells to the
+  // packed radix (validity folds into its key) and leave every other combination on its base path.
   .add_float64_axis("null_frequency", {0, 0.1})
-  // Full (order, null_order) matrix: the CUB path honors order (no nulls by its gate); the
-  // fallback honors both.
+  // Full (order, null_order) matrix: the packed-radix gate engages only for explicit ascending /
+  // nulls-after; the other combinations measure the base routing.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include "segmented_sort_keys.cuh"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_view.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <memory>
+
+namespace cudf {
+namespace detail {
+
+/**
+ * @brief Average and total element-count bounds below which CUB `DeviceSegmentedSort` is preferred
+ *
+ * Chosen from benchmark results and shared by the fixed-width dispatch so its two fast paths agree
+ * on which columns `DeviceSegmentedSort` claims: the packed-radix path takes exactly the complement
+ * of this gate.
+ */
+constexpr size_type MAX_AVG_LIST_SIZE_FOR_FAST_SORT{100};
+constexpr size_type MAX_LIST_SIZE_FOR_FAST_SORT{1 << 18};
+
+/**
+ * @brief Whether a single fixed-width column is small enough to prefer CUB `DeviceSegmentedSort`
+ *
+ * @param num_rows Element count of the column
+ * @param num_offsets Segment-offsets count (the number of segments plus one), matching the
+ *        historical average-size heuristic; the caller guarantees it is nonzero
+ * @return true if CUB `DeviceSegmentedSort` is preferred for this shape
+ */
+inline bool prefer_cub_segmented_sort(size_type num_rows, size_type num_offsets)
+{
+  return (num_rows / num_offsets) < MAX_AVG_LIST_SIZE_FOR_FAST_SORT or
+         num_rows < MAX_LIST_SIZE_FOR_FAST_SORT;
+}
+
+/**
+ * @brief Fixed-width fast path a single key column takes within the explicit-(order, null_order) /
+ * unstable envelope
+ */
+enum class fixed_width_sort_path {
+  comparison,     ///< No fast path applies; fall through to the comparison sort
+  tiered,         ///< Register / warp tiered kernel
+  cub_segmented,  ///< CUB `DeviceSegmentedSort` over the packed rep
+  packed_radix    ///< One global packed-radix sort
+};
+
+/**
+ * @brief Routes a single fixed-width key column to the fast path measured best for its shape
+ *
+ * One segmented sort, four engines picked by type x null-presence x average list size, since each
+ * engine's cost scales differently. Per path (band -> engine -> why it wins):
+ * - Non-tiered numerics (narrow/unsigned ints, `bool`, `DECIMAL32`/`DECIMAL64`) -> packed radix if
+ *   null-bearing or long, else CUB/comparison: the tiered key can't encode them, so keep main's
+ * rule.
+ * - Null-bearing tiered types -> tiered sort: validity folds into the key, no separate null pass.
+ * - No-null past the fast cutoff -> packed radix: bandwidth-bound, cost ~ key bytes, amortized by
+ * long lists.
+ * - No-null `DECIMAL128` -> tiered when tiny, CUB in a sparse-large mid band, tiered above it:
+ * CUB's 16-byte-pair merge tiles cap at 32 elements, so dense large segments would explode into a
+ * radix.
+ * - No-null floating point -> tiered across the short range.
+ * - No-null 8-byte int/chrono -> tiered across the range: the tiered warp kernels beat CUB
+ * `DeviceSegmentedSort` there; 4-byte int/chrono -> tiered: register sorting networks make
+ * comparison cost width-independent for tiny segments.
+ * - Outside the fixed-width fast envelope -> comparison sort.
+ *
+ * @param key The single key column to sort
+ * @param num_rows Element count of the column
+ * @param segment_offsets The segment offsets (segment count plus one); the caller guarantees
+ * non-empty
+ * @param stream CUDA stream used by the `DECIMAL128` mid-band shape gate, if reached
+ * @return the fast path measured best for this column's shape (or `comparison` for none)
+ */
+fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
+                                                   size_type num_rows,
+                                                   column_view const& segment_offsets,
+                                                   rmm::cuda_stream_view stream);
+
+/**
+ * @brief Faster segmented sorted-order for a single fixed-width key column via one radix sort
+ *
+ * Replaces the comparison sort (used for null-bearing or large columns) and
+ * cub::DeviceSegmentedSort (used for the small no-null case) with a single non-segmented radix sort
+ * over a packed key that carries each element's segment, a null class bit, and its value
+ * transformed so the unsigned key order equals the requested value order (`polarity` complements
+ * the value field for descending and picks the null side). Because a fixed-width value is fully
+ * encoded, there is no tie-break: the radix permutation is the final order. Nulls need no post-pass
+ * -- the class bit places them on their configured side within their segment, and their order
+ * among themselves is immaterial under the unstable contract. Engages for any explicit (order,
+ * null_order), which the caller resolves into `polarity`; handles both nullable and non-nullable
+ * columns.
+ *
+ * @param input The fixed-width column whose elements are sorted within each segment
+ * @param segment_offsets Identifies the segments to sort within
+ * @param polarity Key polarity resolved from the requested (order, null_order)
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return Indices that map the column to a segmented sorted order
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_numeric_packed(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/sort/segmented_sort_fixed_width.cu
+++ b/cpp/src/sort/segmented_sort_fixed_width.cu
@@ -1,0 +1,423 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "segmented_sort_fast.cuh"
+#include "segmented_sort_keys.cuh"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/traits.hpp>
+#include <cudf/utilities/type_dispatcher.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cub/device/device_radix_sort.cuh>
+#include <cuda/iterator>
+#include <cuda/std/algorithm>
+#include <cuda/std/bit>
+#include <cuda/std/cmath>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+/**
+ * @brief Maps a fixed-width value to the unsigned key whose ascending order equals value order
+ *
+ * Integrals: an unsigned input sorts by its bit pattern unchanged; a signed input has its sign bit
+ * flipped so every negative precedes every non-negative. `bool` is already the ordered set {0, 1}.
+ * Timestamps/durations order by their signed integer rep, so the rep is extracted and re-encoded
+ * at its width, matching cudf's own radix sort. Floating point takes the order-preserving IEEE-754
+ * flip: every NaN maps to the all-ones key (so all NaNs compare equal and sort after +Inf), and the
+ * sign is mapped so -Inf < finite (incl. +/-0, denormals) < +Inf -- monotone across every finite
+ * value. The transform runs at the input width so the flip lands on the correct bit; the caller
+ * zero-extends to the 32-bit value field, and the equal high bits the widening adds cannot reorder.
+ * Fixed-point reps are signed integers with one column-wide scale, so rep order equals value order.
+ * The type branches are `if constexpr` and ordered so the non-integral cases resolve before
+ * `make_unsigned_t`, which is ill-formed for floating-point and chrono types.
+ */
+template <typename T>
+__device__ inline cuda::std::uint32_t radix_encode_u32(T value)
+{
+  if constexpr (cuda::std::is_same_v<T, bool>) {
+    return value ? cuda::std::uint32_t{1} : cuda::std::uint32_t{0};
+  } else if constexpr (cudf::is_timestamp<T>()) {
+    return radix_encode_u32(value.time_since_epoch().count());
+  } else if constexpr (cudf::is_duration<T>()) {
+    return radix_encode_u32(value.count());
+  } else if constexpr (cuda::std::is_floating_point_v<T>) {
+    if (cuda::std::isnan(value)) { return ~cuda::std::uint32_t{0}; }
+    auto const bits          = cuda::std::bit_cast<cuda::std::uint32_t>(value);
+    auto constexpr sign_mask = cuda::std::uint32_t{1} << (sizeof(cuda::std::uint32_t) * 8 - 1);
+    return (bits & sign_mask) ? ~bits : (bits | sign_mask);
+  } else {
+    using U      = cuda::std::make_unsigned_t<T>;
+    auto encoded = static_cast<U>(value);
+    if constexpr (cuda::std::is_signed_v<T>) {
+      encoded ^= static_cast<U>(U{1} << (sizeof(U) * 8 - 1));
+    }
+    return static_cast<cuda::std::uint32_t>(encoded);
+  }
+}
+
+/**
+ * @brief The eight-byte analogue of `radix_encode_u32` for the `prefix_key96` value words
+ *
+ * Reached for eight-byte element types: `int64`/`uint64`, the `DECIMAL64` rep, `double`, and the
+ * int64-rep timestamps/durations. `bool` never reaches here. Chrono reps are extracted, floating
+ * point takes the IEEE-754 flip (every NaN -> all-ones), and integrals flip the sign bit of the
+ * 64-bit two's-complement pattern -- the same transforms as the 32-bit encoder, at this width.
+ */
+template <typename T>
+__device__ inline cuda::std::uint64_t radix_encode_u64(T value)
+{
+  if constexpr (cudf::is_timestamp<T>()) {
+    return radix_encode_u64(value.time_since_epoch().count());
+  } else if constexpr (cudf::is_duration<T>()) {
+    return radix_encode_u64(value.count());
+  } else if constexpr (cuda::std::is_floating_point_v<T>) {
+    if (cuda::std::isnan(value)) { return ~cuda::std::uint64_t{0}; }
+    auto const bits          = cuda::std::bit_cast<cuda::std::uint64_t>(value);
+    auto constexpr sign_mask = cuda::std::uint64_t{1} << (sizeof(cuda::std::uint64_t) * 8 - 1);
+    return (bits & sign_mask) ? ~bits : (bits | sign_mask);
+  } else {
+    using U      = cuda::std::make_unsigned_t<T>;
+    auto encoded = static_cast<U>(value);
+    if constexpr (cuda::std::is_signed_v<T>) {
+      encoded ^= static_cast<U>(U{1} << (sizeof(U) * 8 - 1));
+    }
+    return static_cast<cuda::std::uint64_t>(encoded);
+  }
+}
+
+/**
+ * @brief Builds the single-`uint64` packed key for a fixed-width element of width four bytes or
+ * less
+ *
+ * The word is laid out most- to least-significant as `[segment : S bits][class : 1 bit][value :
+ * 32 bits]`, with `S = bit_width(num_segments)`; an unsigned compare therefore orders by segment,
+ * then by the polarity's null placement (the class bit is 1 for a null under nulls-last, 1 for a
+ * valid under nulls-first), then by the radix-encoded value -- complemented within its 32-bit field
+ * when descending, which exactly reverses value order without reaching the class bit. The class
+ * bit sits at bit 32, one bit above the 32-bit value field and (since `S <= 31`) strictly below
+ * the segment field, so a null carries a zero value yet still sorts on its configured side of every
+ * valid element in its segment regardless of that element's value, and no value can reach the class
+ * bit. Any bits between the class bit and the segment field are left zero and identical for all
+ * elements, so they never affect the order.
+ */
+template <typename T>
+struct numeric_packed_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  int const segment_bits;
+  sort_polarity const polarity;
+  __device__ cuda::std::uint64_t operator()(size_type idx) const
+  {
+    auto const segment_part = static_cast<cuda::std::uint64_t>(d_segment_ids[idx])
+                              << (64 - segment_bits);
+    if (has_nulls && d_input.is_null(idx)) {
+      // Null: only its class bit one above the value field; the value stays zero and unread.
+      return segment_part | (static_cast<cuda::std::uint64_t>(polarity.element_class(true))
+                             << (sizeof(cuda::std::uint32_t) * 8));
+    }
+    return segment_part |
+           (static_cast<cuda::std::uint64_t>(polarity.element_class(false))
+            << (sizeof(cuda::std::uint32_t) * 8)) |
+           static_cast<cuda::std::uint64_t>(radix_encode_u32<T>(d_input.element<T>(idx)) ^
+                                            polarity.value_mask32());
+  }
+};
+
+/**
+ * @brief Builds the `prefix_key96` packed key for an eight-byte fixed-width element
+ *
+ * Reuses the strings path's key: `seg_null` packs the segment ordinal in bits 1..31 and the
+ * polarity's class bit in bit 0 (via `pack_seg_null`), so the segment dominates and a null sorts
+ * on its configured side of every valid element sharing its segment; the two window words carry
+ * the radix-encoded 64-bit value split most- then least-significant -- complemented when
+ * descending, which reverses value order and distributes over the split -- so the
+ * `prefix_decomposer` orders tied segments by the full value. A null leaves the value words zero
+ * and unread.
+ */
+template <typename T>
+struct numeric_packed_key_builder64 {
+  size_type const* d_segment_ids;
+  column_device_view const d_input;
+  bool const has_nulls;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type idx) const
+  {
+    auto const segment = static_cast<cuda::std::uint32_t>(d_segment_ids[idx]);
+    if (has_nulls && d_input.is_null(idx)) {
+      return prefix_key96{pack_seg_null(segment, polarity.element_class(true)), 0u, 0u};
+    }
+    prefix_key96 key{pack_seg_null(segment, polarity.element_class(false)), 0u, 0u};
+    split_prefix(radix_encode_u64<T>(d_input.element<T>(idx)) ^ polarity.value_mask64(),
+                 key.prefix_hi,
+                 key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Sorts a single fixed-width key column within its segments by one global radix sort
+ *
+ * The whole value is encoded into the key, so there is no tie-break: the radix order is the final
+ * order. Elements four bytes wide or less use one `uint64` key (eight byte-passes); eight-byte
+ * elements use the twelve-byte `prefix_key96` (twelve byte-passes); the `DECIMAL128` rep takes the
+ * narrowest lossless key its value range admits (`dec128_segmented_radix_sort`). Each carries the
+ * per-element index as the paired value, so the sorted indices are the segmented sorted order. The
+ * enabled overload
+ * matches every fixed-width type the packed key encodes losslessly -- integrals (incl. `bool`),
+ * floating point, timestamps/durations, and the `DECIMAL32/64/128` reps `dispatch_storage_type`
+ * maps to `int32`/`int64`/`__int128` -- so only the non-fixed-width types (string, list, struct,
+ * dictionary) take the failing overload, which the caller's gate never reaches at run time.
+ */
+struct numeric_packed_sort_fn {
+  // Compile-time counterpart of the runtime gate `is_numeric_packed_radix_supported`: it must
+  // accept exactly the same types, so widen the two together. Every fixed-width type the packed key
+  // encodes losslessly -- integrals (incl. bool), floating point, timestamps/durations, and the
+  // DECIMAL32/64 storage reps (int32/int64). The non-fixed-width types (string, list, struct,
+  // dictionary) take the failing overload; the 16-byte DECIMAL128 rep is fenced off at run time.
+  template <typename T>
+  static constexpr bool is_supported()
+  {
+    return cudf::is_integral<T>() or cudf::is_floating_point<T>() or cudf::is_chrono<T>();
+  }
+
+  template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
+  void operator()(column_device_view const& d_input,
+                  size_type const* d_segment_ids,
+                  bool has_nulls,
+                  sort_polarity polarity,
+                  int segment_bits,
+                  size_type num_elements,
+                  size_type* d_indices_out,
+                  rmm::cuda_stream_view stream) const
+  {
+    auto const counting = cuda::counting_iterator<size_type>{0};
+    rmm::device_uvector<size_type> indices_in(num_elements, stream);
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     indices_in.begin(),
+                     indices_in.end(),
+                     0);
+
+    if constexpr (sizeof(T) <= 4) {
+      // The value occupies a fixed 32 bits and the null flag one bit; the segment field takes the
+      // top S = bit_width(num_segments) bits. num_segments is a size_type, so S never exceeds
+      // bit_width(size_type max) = 31 and S + 1 + 32 <= 64 -- all three fields always fit the key
+      // with the null flag strictly above the value and strictly below the segment field.
+      static_assert(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(
+                      cuda::std::numeric_limits<size_type>::max())) +
+                        1 + 32 <=
+                      64,
+                    "packed numeric key fields exceed the 64-bit key for some segment count");
+      rmm::device_uvector<cuda::std::uint64_t> keys_in(num_elements, stream);
+      rmm::device_uvector<cuda::std::uint64_t> keys_out(num_elements, stream);
+      thrust::transform(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        counting,
+        counting + num_elements,
+        keys_in.begin(),
+        numeric_packed_key_builder<T>{d_segment_ids, d_input, has_nulls, segment_bits, polarity});
+      // One global radix over the full 64 bits (segment in the high bits, value in the low): eight
+      // byte-passes. The two-stage temporary-storage call is wrapped so the storage is released
+      // before the sort returns.
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        keys_in.data(),
+                                        keys_out.data(),
+                                        indices_in.data(),
+                                        d_indices_out,
+                                        num_elements,
+                                        0,
+                                        static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                        stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        keys_in.data(),
+                                        keys_out.data(),
+                                        indices_in.data(),
+                                        d_indices_out,
+                                        num_elements,
+                                        0,
+                                        static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                        stream.value());
+      }
+    } else if constexpr (sizeof(T) == 8) {
+      // Eight-byte value: reuse prefix_key96 {seg_null, value_hi, value_lo}. The segment ordinal
+      // rides seg_null's high 31 bits and the null flag its bit 0, so (label << 1) | flag must fit
+      // a uint32 for every size_type segment count.
+      static_assert(2ull * cuda::std::numeric_limits<size_type>::max() + 1ull <=
+                      cuda::std::numeric_limits<cuda::std::uint32_t>::max(),
+                    "size_type segment label does not fit prefix_key96::seg_null after the shift");
+      rmm::device_uvector<prefix_key96> keys_in(num_elements, stream);
+      rmm::device_uvector<prefix_key96> keys_out(num_elements, stream);
+      thrust::transform(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        counting,
+        counting + num_elements,
+        keys_in.begin(),
+        numeric_packed_key_builder64<T>{d_segment_ids, d_input, has_nulls, polarity});
+      auto const decomposer = prefix_decomposer{};
+      // seg_null = (segment ordinal << 1) | null flag is significant only to segment_bits + 1 bits;
+      // the constant-zero bits above it are dropped from the radix end bit, skipping their passes
+      // exactly as dec128_segmented_radix_sort's key96 path does for the identical key layout.
+      auto const key_bits = cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8),
+                                           64 + cuda::std::min(32, segment_bits + 1));
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        keys_in.data(),
+                                        keys_out.data(),
+                                        indices_in.data(),
+                                        d_indices_out,
+                                        num_elements,
+                                        decomposer,
+                                        0,
+                                        key_bits,
+                                        stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        keys_in.data(),
+                                        keys_out.data(),
+                                        indices_in.data(),
+                                        d_indices_out,
+                                        num_elements,
+                                        decomposer,
+                                        0,
+                                        key_bits,
+                                        stream.value());
+      }
+    } else {
+      // The sixteen-byte DECIMAL128 (`__int128`) rep is out of this stage's scope: the run-time
+      // gate `is_numeric_packed_radix_supported` excludes it, so this branch is an unreached
+      // fail-safe until the DECIMAL128 engine lands.
+      CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
+    }
+  }
+
+  template <typename T, CUDF_ENABLE_IF(not is_supported<T>())>
+  void operator()(column_device_view const&,
+                  size_type const*,
+                  bool,
+                  sort_polarity,
+                  int,
+                  size_type,
+                  size_type*,
+                  rmm::cuda_stream_view) const
+  {
+    CUDF_FAIL("Column type cannot be used with the numeric packed-radix segmented sort");
+  }
+};
+
+/**
+ * @brief Run-time predicate for the numeric packed-radix fast path on a key column's type
+ *
+ * True for every fixed-width type the path encodes losslessly: integrals (including `bool`), the
+ * `DECIMAL32/64` fixed-point reps, floating point, and timestamps/durations. `DECIMAL128` (16-byte
+ * rep) and the non-fixed-width types (string, list, struct, dictionary) are excluded.
+ *
+ * @param type The key column's data type
+ * @return true if the type is eligible for the packed-radix fast path
+ */
+inline bool is_numeric_packed_radix_supported(data_type type)
+{
+  return cudf::is_integral(type) or
+         (cudf::is_fixed_point(type) and type.id() != type_id::DECIMAL128) or
+         cudf::is_floating_point(type) or cudf::is_chrono(type);
+}
+
+}  // namespace
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_numeric_packed(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+
+  // Dense segment ordinals (0, 1, ... across the segments), exactly as the strings path labels
+  // them: the ordinal maximum is num_segments - 1, so the key's segment field needs only
+  // bit_width(num_segments) bits, and an empty segment simply contributes no element and skips a
+  // label, preserving cross-segment order.
+  rmm::device_uvector<size_type> segment_ids(num_elements, stream);
+  label_segments(segment_offsets.begin<size_type>(),
+                 segment_offsets.end<size_type>(),
+                 segment_ids.begin(),
+                 segment_ids.end(),
+                 stream);
+
+  auto const d_input   = column_device_view::create(input, stream);
+  auto const has_nulls = input.has_nulls();
+  auto const segment_bits =
+    static_cast<int>(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(num_segments)));
+
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+
+  // Dispatch on the storage type so DECIMAL32/DECIMAL64 sort by their int32/int64 rep; the functor
+  // picks the uint64 or prefix_key96 key by width and writes the sorted indices into the output.
+  cudf::type_dispatcher<dispatch_storage_type>(input.type(),
+                                               numeric_packed_sort_fn{},
+                                               *d_input,
+                                               segment_ids.data(),
+                                               has_nulls,
+                                               polarity,
+                                               segment_bits,
+                                               num_elements,
+                                               sorted_indices->mutable_view().begin<size_type>(),
+                                               stream);
+  return sorted_indices;
+}
+
+fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
+                                                   size_type num_rows,
+                                                   column_view const& segment_offsets,
+                                                   [[maybe_unused]] rmm::cuda_stream_view stream)
+{
+  auto const type = key.type();
+  // String / nested keys have no fixed-width fast path.
+  if (not is_numeric_packed_radix_supported(type)) { return fixed_width_sort_path::comparison; }
+
+  // avg_list_size uses num_rows / num_offsets, the heuristic prefer_cub_segmented_sort also uses.
+  auto const num_offsets   = segment_offsets.size();
+  auto const avg_list_size = num_rows / num_offsets;
+
+  // Validity folds into the packed key, so a null-bearing column skips the separate null partition
+  // at any list size.
+  if (key.has_nulls()) { return fixed_width_sort_path::packed_radix; }
+  // Long lists amortize the global packed-key radix's bandwidth-bound pass.
+  if (avg_list_size >= MAX_AVG_LIST_SIZE_FOR_FAST_SORT) {
+    return fixed_width_sort_path::packed_radix;
+  }
+  // The short no-null remainder keeps the CUB-or-comparison decision of the gate below.
+  return fixed_width_sort_path::comparison;
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -1,20 +1,27 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #pragma once
 
+#include "segmented_sort_fast.cuh"
+#include "segmented_sort_keys.cuh"
 #include "sort.hpp"
 
+#include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/copy.hpp>
 #include <cudf/detail/gather.hpp>
 #include <cudf/detail/sequence.hpp>
 #include <cudf/detail/sorting.hpp>
+#include <cudf/detail/utilities/vector_factories.hpp>
+#include <cudf/table/table_view.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
 #include <rmm/device_uvector.hpp>
 
 #include <cub/device/device_segmented_sort.cuh>
@@ -180,19 +187,19 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
  * The segments are added to the input table-view keys so they
  * are lexicographically sorted within the segmented groups.
  *
- * ```
+ * @code{.pseudo}
  * Example 1:
  * num_rows = 10
  * offsets = {0, 3, 7, 10}
  * segment-indices -> { 3,3,3, 7,7,7,7, 10,10,10 }
- * ```
+ * @endcode
  *
- * ```
+ * @code{.pseudo}
  * Example 2: (offsets do not cover all indices)
  * num_rows = 10
  * offsets = {3, 7}
  * segment-indices -> { 0,1,2, 7,7,7,7, 8,9,10 }
- * ```
+ * @endcode
  *
  * @param num_rows Total number of rows in the input keys to sort
  * @param offsets The offsets identifying the segments
@@ -201,6 +208,39 @@ std::unique_ptr<column> fast_segmented_sorted_order(column_view const& input,
 rmm::device_uvector<size_type> get_segment_indices(size_type num_rows,
                                                    column_view const& offsets,
                                                    rmm::cuda_stream_view stream);
+
+/**
+ * @brief Whether the segment offsets span every row `[0, num_rows]` -- the precondition the packed,
+ * tiered, and strings fast paths assume
+ *
+ * Those paths label elements by dense segment ordinal and index the output by raw offset, so they
+ * are correct only when the offsets cover the whole element range. The public contract allows
+ * offsets that skip leading or trailing rows (left unsorted) or a single-index offset (no rows
+ * sorted); those must take the comparison path. Requiring at least two offsets also rules out the
+ * `num_segments == 0` case, whose zero-width segment field would make the packed builders shift a
+ * 64-bit value by 64 (undefined behavior). Reads only the first and last offset. `sort_lists`, the
+ * primary caller, always passes full-span offsets, so it stays on the fast path.
+ *
+ * @param segment_offsets The segment offsets (segment count plus one)
+ * @param num_rows Element count the offsets must span
+ * @param stream CUDA stream used for the two boundary reads
+ * @return true when there are at least two offsets spanning `[0, num_rows]`
+ */
+inline bool fast_path_offsets_cover_all_rows(column_view const& segment_offsets,
+                                             size_type num_rows,
+                                             rmm::cuda_stream_view stream)
+{
+  auto const num_offsets = segment_offsets.size();
+  if (num_offsets < 2) { return false; }
+  // Both boundary reads are enqueued async on `stream`, so the probe pays one synchronization.
+  auto const first = cudf::detail::make_host_vector_async(
+    device_span<size_type const>{segment_offsets.begin<size_type>(), 1}, stream);
+  auto const last = cudf::detail::make_host_vector_async(
+    device_span<size_type const>{segment_offsets.begin<size_type>() + (num_offsets - 1), 1},
+    stream);
+  stream.synchronize();
+  return first[0] == 0 and last[0] == num_rows;
+}
 
 /**
  * @brief Segmented sorted-order utility
@@ -242,21 +282,37 @@ std::unique_ptr<column> segmented_sorted_order_common(
                  "Mismatch between number of columns and null_precedence size.");
   }
 
-  // the average row size for which to prefer fast sort
-  constexpr cudf::size_type MAX_AVG_LIST_SIZE_FOR_FAST_SORT{100};
-  // the maximum row count for which to prefer fast sort
-  constexpr cudf::size_type MAX_LIST_SIZE_FOR_FAST_SORT{1 << 18};
+  // fast-path for a single fixed-width key column sorted ascending with nulls last (unstable only).
+  // `choose_fixed_width_sort_path` routes a no-null column with long enough lists to one global
+  // packed-radix sort that reproduces the comparison sort's ascending / nulls-last order without a
+  // cardinality-scaled cost; every other shape takes the comparison path. The order and null
+  // precedence must be stated explicitly, so any other configuration -- including the
+  // defaulted-argument cases -- falls through unchanged.
+  if constexpr (method == sort_method::UNSTABLE) {
+    // The constant-time order / null-precedence checks run first: the offsets-coverage probe
+    // synchronizes the stream, so only inputs already known to be ascending / nulls-after pay it.
+    if (keys.num_columns() == 1 and segment_offsets.size() > 0 and column_order.size() == 1 and
+        column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
+        null_precedence.front() == null_order::AFTER and
+        fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+      auto const path =
+        choose_fixed_width_sort_path(keys.column(0), keys.num_rows(), segment_offsets, stream);
+      if (path == fixed_width_sort_path::packed_radix) {
+        return fast_segmented_sorted_order_numeric_packed(
+          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+      }
+    }
+  }
 
   // fast-path for single column sort:
   // - single-column table
-  // - not stable-sort
+  // - works for both stable and unstable sort
   // - no nulls and allowable fixed-width type
   // - size and width are limited -- based on benchmark results
   if (keys.num_columns() == 1 and
       column_fast_sort_fn<method>::is_fast_sort_supported(keys.column(0)) and
       (segment_offsets.size() > 0) and
-      (((keys.num_rows() / segment_offsets.size()) < MAX_AVG_LIST_SIZE_FOR_FAST_SORT) or
-       (keys.num_rows() < MAX_LIST_SIZE_FOR_FAST_SORT))) {
+      prefer_cub_segmented_sort(keys.num_rows(), segment_offsets.size())) {
     auto const col_order = column_order.empty() ? order::ASCENDING : column_order.front();
     return fast_segmented_sorted_order<method>(
       keys.column(0), segment_offsets, col_order, stream, mr);

--- a/cpp/src/sort/segmented_sort_keys.cuh
+++ b/cpp/src/sort/segmented_sort_keys.cuh
@@ -1,0 +1,138 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/types.hpp>
+
+#include <cuda/std/cstdint>
+#include <cuda/std/tuple>
+
+namespace cudf {
+namespace detail {
+
+/**
+ * @brief Runtime key polarity realizing one explicit (order, null_order) on the segmented-sort
+ * fast paths
+ *
+ * Every fast-path engine orders elements by an unsigned comparison of a packed key, so the
+ * requested configuration is folded into the key bits themselves -- one XOR-class operation per
+ * element -- rather than into per-engine comparators, which would multiply kernel instantiations.
+ * `descending` complements the encoded value field: the complement is a strictly order-reversing
+ * bijection on the field's unsigned range, and confining the mask to the value field's exact width
+ * leaves the class/segment bits above it untouched, so within-segment value order reverses while
+ * everything else is preserved. `nulls_first` picks the null class bit so nulls sort on the
+ * requested side of a segment's valid elements. cudf's `null_order` is comparator-level -- a
+ * DESCENDING sort swaps the comparison operands, inverting null placement too -- so the caller
+ * resolves `nulls_first = (null_order == BEFORE) XOR descending` and relaxes a zero-null column to
+ * the shipped nulls-last polarity. The only current caller constructs the default polarity, gated
+ * to an explicit ascending / nulls-after request; the non-default states are exercised once that
+ * gate widens to the full matrix. The default `{false, false}` state reproduces the shipped
+ * ascending / nulls-last keys bit for bit.
+ */
+struct sort_polarity {
+  bool descending  = false;
+  bool nulls_first = false;
+
+  /// Class bit for a valid (0/1) or null (1/0) element: unsigned key order then places nulls on
+  /// the requested side of every valid element; the tiered pad class (2) stays strictly above both.
+  __host__ __device__ cuda::std::uint32_t element_class(bool is_null) const
+  {
+    return static_cast<cuda::std::uint32_t>(is_null != nulls_first);
+  }
+  /// XOR mask reversing a 32-bit encoded value's unsigned order when descending.
+  __host__ __device__ cuda::std::uint32_t value_mask32() const
+  {
+    return descending ? ~cuda::std::uint32_t{0} : cuda::std::uint32_t{0};
+  }
+  /// XOR mask reversing a 64-bit encoded value's unsigned order when descending.
+  __host__ __device__ cuda::std::uint64_t value_mask64() const
+  {
+    return descending ? ~cuda::std::uint64_t{0} : cuda::std::uint64_t{0};
+  }
+};
+
+/**
+ * @brief Fixed-width radix key ordering runs still tied after the single-`uint64` first pass
+ *
+ * Twelve bytes with no padding, so one global radix decomposes it to exactly 96 bits (12 passes)
+ * while still carrying a full eight-byte window; key storage size is the cost driver for this sort,
+ * so dropping the four padding bytes a 16-byte key would carry is a direct data-movement win. The
+ * first sort uses the single-`uint64` `packed_key_layout` instead; this key drives only the
+ * iterative passes that reorder runs still tied after it. The fields are ordered most- to
+ * least-significant. `seg_null` packs a dense run rank in its high 31 bits and the null flag in bit
+ * 0 (`(rank << 1) | is_null`): the rank dominates so a radix by it preserves every order an earlier
+ * pass resolved and a pass only reorders within a tied run, and within a rank a null (bit 0 = 1)
+ * sorts after every non-null (bit 0 = 0). `prefix_hi` and `prefix_lo` are the most- and
+ * least-significant four bytes of the element's next eight window bytes packed big-endian (byte 0
+ * most significant, low bytes zero-filled); `prefix_hi` is the more significant field, so comparing
+ * `prefix_hi` then `prefix_lo` reproduces unsigned-byte lexicographic order over the window. A null
+ * element carries unread zero window words, never its string bytes.
+ */
+struct prefix_key96 {
+  cuda::std::uint32_t seg_null;
+  cuda::std::uint32_t prefix_hi;
+  cuda::std::uint32_t prefix_lo;
+};
+
+// Twelve tightly-packed bytes is the whole point: it decomposes to 96 radix bits (12 byte-passes),
+// and padding to sixteen would restore the four data-movement bytes this key exists to shed.
+static_assert(sizeof(prefix_key96) == 12 and alignof(prefix_key96) == 4,
+              "prefix_key96 must stay 12 bytes with 4-byte alignment");
+
+/**
+ * @brief Decomposes a `prefix_key96` into its fields for `cub::DeviceRadixSort`
+ *
+ * The leftmost tuple element is the most significant, so one ascending radix pass sorts by the
+ * packed run-rank-and-null field, then by the high window word, then by the low window word -- i.e.
+ * by run rank, then null flag, then the eight-byte window in unsigned-byte lexicographic order.
+ */
+struct prefix_decomposer {
+  __device__ cuda::std::tuple<cuda::std::uint32_t&, cuda::std::uint32_t&, cuda::std::uint32_t&>
+  operator()(prefix_key96& key) const
+  {
+    return {key.seg_null, key.prefix_hi, key.prefix_lo};
+  }
+};
+
+/**
+ * @brief True when two keys are bit-for-bit equal, i.e. the same run of an unresolved tie
+ */
+__device__ inline bool keys_equal(prefix_key96 const& a, prefix_key96 const& b)
+{
+  return a.seg_null == b.seg_null && a.prefix_hi == b.prefix_hi && a.prefix_lo == b.prefix_lo;
+}
+
+/**
+ * @brief Packs a dense run rank and a null flag into one 32-bit field
+ *
+ * The rank occupies bits 1..31 and the null flag bit 0, so the rank dominates the ordering and a
+ * null sorts after a non-null sharing the rank (null_order::AFTER). The run rank comes from an
+ * inclusive scan over run-head flags, so it is bounded by the element count (<= 2^31 - 1, a
+ * `size_type`); `(rank << 1) | flag` is then at most 2^32 - 1 and never overflows the field. A
+ * `static_assert` in the caller proves this for every `size_type` value.
+ */
+__device__ inline cuda::std::uint32_t pack_seg_null(cuda::std::uint32_t label,
+                                                    cuda::std::uint32_t flag)
+{
+  return (label << 1) | flag;
+}
+
+/**
+ * @brief Splits a big-endian-packed eight-byte window into a `prefix_key96`'s two window words
+ *
+ * `prefix_hi` takes the most-significant four bytes and `prefix_lo` the least-significant four, so
+ * comparing `prefix_hi` then `prefix_lo` reproduces an unsigned comparison of the full eight bytes.
+ */
+__device__ inline void split_prefix(cuda::std::uint64_t packed,
+                                    cuda::std::uint32_t& prefix_hi,
+                                    cuda::std::uint32_t& prefix_lo)
+{
+  prefix_hi = static_cast<cuda::std::uint32_t>(packed >> 32);
+  prefix_lo = static_cast<cuda::std::uint32_t>(packed & 0xFFFF'FFFFu);
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -6,10 +6,17 @@
 #include <cudf_test/base_fixture.hpp>
 #include <cudf_test/column_utilities.hpp>
 #include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/iterator_utilities.hpp>
 #include <cudf_test/type_lists.hpp>
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/lists/sorting.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+using namespace cudf::test::iterators;
 
 template <typename T>
 using LCW = cudf::test::lists_column_wrapper<T, int32_t>;
@@ -176,6 +183,280 @@ TEST_F(SortListsInt, NullRows)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), l);
 }
 
+namespace {
+// Sorts `input` under the given explicit (order, null_order) -- ascending / nulls-after by default
+// -- through the fast path (`sort_lists`) and the comparison path (`stable_sort_lists`), asserting
+// both equal `expected`. The fast path must reproduce the comparison path's order exactly; only
+// speed differs. The stable assertion doubles as a run-time check of every hand- or host-computed
+// expectation against the comparison semantics.
+void expect_both_sort_paths_match(cudf::lists_column_view const& input,
+                                  cudf::column_view const& expected,
+                                  cudf::order column_order         = cudf::order::ASCENDING,
+                                  cudf::null_order null_precedence = cudf::null_order::AFTER)
+{
+  auto const sorted = cudf::lists::sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted->view(), expected);
+  auto const stable_sorted = cudf::lists::stable_sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted->view(), expected);
+}
+
+// EQUIVALENT variant of `expect_both_sort_paths_match` for floating point. Under the unstable
+// contract -0.0/+0.0 and distinct NaN bit patterns are interchangeable, so the exact per-slot bytes
+// within such a group may differ between the fast and comparison paths; EQUIVALENT accepts that
+// while still pinning the order of every distinct finite value, the infinities, and the NaN block's
+// position.
+void expect_both_sort_paths_equivalent(cudf::lists_column_view const& input,
+                                       cudf::column_view const& expected,
+                                       cudf::order column_order         = cudf::order::ASCENDING,
+                                       cudf::null_order null_precedence = cudf::null_order::AFTER)
+{
+  auto const sorted = cudf::lists::sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted->view(), expected);
+  auto const stable_sorted = cudf::lists::stable_sort_lists(input, column_order, null_precedence);
+  CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted->view(), expected);
+}
+
+// Wraps a leaf column as a single-row LIST (every element in one list row) -- the shape the
+// value-ordering tests for the wide chrono and decimal128 keys need, so the sort orders within that
+// one segment. Element-level nulls live in the leaf's validity.
+std::unique_ptr<cudf::column> as_single_row_list(std::unique_ptr<cudf::column> leaf)
+{
+  auto const n = static_cast<cudf::size_type>(leaf->size());
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+  return cudf::make_lists_column(1, offsets.release(), std::move(leaf), 0, {});
+}
+}  // namespace
+
+// Sign-flip correctness at the signed-integer boundaries: INT_MIN must sort first and INT_MAX last
+// among the non-nulls, with every negative ahead of every non-negative, for both rep widths. The
+// null-bearing rows route to the tiered kernel (which orders nulls last under null_order::AFTER);
+// the int32 rep takes its uint64 tiered key and the int64 rep the unsigned __int128 key. Verified
+// against the comparison path.
+TEST_F(SortListsInt, NumericPackedNegativesAndBounds)
+{
+  {  // int32: the <= 4-byte uint64 tiered key.
+    auto constexpr lo = std::numeric_limits<int32_t>::min();
+    auto constexpr hi = std::numeric_limits<int32_t>::max();
+    std::vector<bool> const in_valids{true, true, false, true, true, true, false};
+    LCW<int32_t> input{{{hi, -1, 0, lo, 0, 1, 0}, in_valids.begin()}};
+    std::vector<bool> const ex_valids{true, true, true, true, true, false, false};
+    LCW<int32_t> expected{{{lo, -1, 0, 1, hi, 0, 0}, ex_valids.begin()}};
+    expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+  }
+  {  // int64: the 8-byte unsigned __int128 tiered key. The file-wide `LCW` alias fixes its source
+     // element type to `int32_t`, which cannot represent the 64-bit bounds, so this block uses a
+     // wrapper sourcing directly from `int64_t`.
+    using LCW64       = cudf::test::lists_column_wrapper<int64_t>;
+    auto constexpr lo = std::numeric_limits<int64_t>::min();
+    auto constexpr hi = std::numeric_limits<int64_t>::max();
+    std::vector<bool> const in_valids{true, true, false, true, true, true, false};
+    LCW64 input{{{hi, -1, 0, lo, 0, 1, 0}, in_valids.begin()}};
+    std::vector<bool> const ex_valids{true, true, true, true, true, false, false};
+    LCW64 expected{{{lo, -1, 0, 1, hi, 0, 0}, ex_valids.begin()}};
+    expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+  }
+}
+
+// Empty, single-element, and duplicate rows through the tiered kernel. A null element routes the
+// column there (any null-bearing column takes the tiered path, which orders nulls last), so these
+// small shapes exercise the network tier: an empty row contributes no slots, a single-element row
+// is trivially ordered, an all-duplicate row keeps its value, and the last row's non-nulls sort
+// ascending with the null placed last under null_order::AFTER. The default-order Empty/Single tests
+// cover the same shapes on the comparison path.
+TEST_F(SortListsInt, NumericPackedEmptyAndSingleRows)
+{
+  std::vector<bool> const in_valids{true, false, true};
+  LCW<int32_t> input{LCW<int32_t>{},
+                     LCW<int32_t>{5},
+                     LCW<int32_t>{-3, -3},
+                     LCW<int32_t>{{2, 7, -1}, in_valids.begin()}};
+  std::vector<bool> const ex_valids{true, true, false};
+  LCW<int32_t> expected{LCW<int32_t>{},
+                        LCW<int32_t>{5},
+                        LCW<int32_t>{-3, -3},
+                        LCW<int32_t>{{-1, 2, 7}, ex_valids.begin()}};
+  expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+}
+
+// Pre-epoch (negative rep) and post-epoch timestamps plus a null, for both rep widths:
+// TIMESTAMP_DAYS (int32 rep -> uint64 tiered key) and TIMESTAMP_MILLISECONDS (int64 rep -> unsigned
+// __int128 key). The null-bearing rows route to the tiered kernel; the signed flip orders negatives
+// before non-negatives, so pre-epoch sorts first, and the null collects last under AFTER. Chrono
+// values arrive as wrappers keyed by their extracted rep, so this also guards the is_timestamp
+// rep-extraction branch. Verified against the comparison path.
+TEST_F(SortListsInt, NumericPackedTimestamps)
+{
+  {  // TIMESTAMP_DAYS: int32 rep, the <= 4-byte uint64 tiered key.
+    std::vector<int32_t> const in{100, -50, 0, 0, 25};
+    std::vector<int32_t> const ex{-50, 0, 25, 100, 0};
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_D>(in.begin(), in.end(), null_at(2))
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_D>(ex.begin(), ex.end(), null_at(4))
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // TIMESTAMP_MILLISECONDS: int64 rep exceeding int32, the 8-byte unsigned __int128 tiered key.
+    auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;  // 5e9 > INT32_MAX, post-epoch
+    std::vector<int64_t> const in{big, -big, 0, 1, -1};
+    std::vector<int64_t> const ex{-big, -1, 1, big, 0};
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(in.begin(), in.end(), null_at(2))
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(ex.begin(), ex.end(), null_at(4))
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
+// Null-bearing BOOL8: `bool` is packed-radix-supported but not tiered, so any null routes it to the
+// packed radix at any list size. Exercises the bool branch of `radix_encode_u32` plus the packed
+// key's null bit, which no other test reaches (the TYPED Null test skips bool and the
+// segmented-sort Bool test is no-null on the legacy CUB path).
+TEST_F(SortListsInt, NumericPackedBoolWithNulls)
+{
+  std::vector<bool> const in_valids{true, true, false, true, true, false, true};
+  auto input =
+    as_single_row_list(cudf::test::fixed_width_column_wrapper<bool>(
+                         {true, false, true, true, false, false, false}, in_valids.begin())
+                         .release());
+  std::vector<bool> const ex_valids{true, true, true, true, true, false, false};
+  auto expected =
+    as_single_row_list(cudf::test::fixed_width_column_wrapper<bool>(
+                         {false, false, false, true, true, false, false}, ex_valids.begin())
+                         .release());
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// The exact average-list-size cells of the packed-radix gate (avg >= 100): a 200-element single row
+// (two offsets -> average exactly 100) is the first packed-radix shape, and a 198-element row
+// (average 99) the last tiered shape. Both must reproduce the comparison order, pinning the gate's
+// >= boundary, which the other tests straddle only from a distance (20 vs 110).
+TEST_F(SortListsInt, NumericPackedRadixAvgGateBoundary)
+{
+  auto const check_single_row = [](cudf::size_type n) {
+    std::vector<int32_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = n / 2 - i;
+    }
+    std::vector<int32_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_single_row(200);  // average exactly 100 -> the first packed-radix cell
+  check_single_row(198);  // average 99 -> the last tiered cell
+}
+
+// No-null long lists (average at/above the packed-radix cutoff) route to the one-shot packed-radix
+// sort for every supported type -- the only path that claims the long-list band. A single row of
+// ~two hundred distinct values spanning the sign boundary, for the three key widths: int32, int64
+// (beyond the 32-bit range), and decimal128 (into the high value words). Each is checked against
+// the comparison sort's ascending order.
+TEST_F(SortListsInt, NumericPackedRadixLongLists)
+{
+  cudf::size_type const n = 220;  // single row, average 110 -> packed radix
+  {                               // int32
+    std::vector<int32_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = n / 2 - i;
+    }
+    std::vector<int32_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int32_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // int64 beyond the 32-bit range
+    auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;
+    std::vector<int64_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = (static_cast<int64_t>(n / 2) - i) * big;
+    }
+    std::vector<int64_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // decimal128 into the high value words
+    auto constexpr scale = numeric::scale_type{0};
+    auto const k         = [] {
+      __int128_t v = 1;
+      for (int i = 0; i < 30; ++i) {
+        v *= 10;
+      }
+      return v;
+    }();
+    std::vector<__int128_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<__int128_t>(n / 2 - i) * k;
+    }
+    std::vector<__int128_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
+// No-null non-tiered types reach packed_radix only when num_rows >= 1<<18 AND avg >= 100 at once
+// (prefer_cub_segmented_sort's OR becomes an AND when negated) -- a route no other test takes:
+// TYPED_TEST(SortLists, Null) covers these types' has-nulls key layout at tiny scale only. One
+// no-null row of 1<<18 elements satisfies both halves, exercising the no-null packed key (no
+// null-class bit, full value budget) for the narrow/unsigned and small-decimal encodings.
+TEST_F(SortListsInt, NumericPackedRadixNoNullNarrowTypes)
+{
+  cudf::size_type const n = 1 << 18;
+  auto const check        = [&](auto tag) {
+    using T = decltype(tag);
+    std::vector<T> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<T>((static_cast<int64_t>(n) - i) % 60'000);
+    }
+    std::vector<T> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input =
+      as_single_row_list(cudf::test::fixed_width_column_wrapper<T>(in.begin(), in.end()).release());
+    auto expected =
+      as_single_row_list(cudf::test::fixed_width_column_wrapper<T>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check(uint16_t{});
+  check(int16_t{});
+  check(uint64_t{});
+
+  // DECIMAL32/64 (non-tiered) take the same no-null packed radix over their int32/int64 rep.
+  auto const check_decimal = [&](auto rep_tag) {
+    using Rep            = decltype(rep_tag);
+    auto constexpr scale = numeric::scale_type{0};
+    std::vector<Rep> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = static_cast<Rep>((static_cast<int64_t>(n) - i) % 60'000);
+    }
+    std::vector<Rep> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<Rep>(in.begin(), in.end(), scale).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<Rep>(ex.begin(), ex.end(), scale).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_decimal(int32_t{});  // DECIMAL32.
+  check_decimal(int64_t{});  // DECIMAL64.
+}
+
 TEST_F(SortListsInt, NestedListElement)
 {
   using T = int;
@@ -307,9 +588,10 @@ TEST_F(SortListsDouble, InfinityAndNaN)
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_lists->view(), expected);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted_lists->view(), expected);
   }
-  // This data includes a row with over 200 elements to test the
-  // radix sort is not used in the logic path in segmented_sort.
-  // Technically radix sort is not expected to be used in either case.
+  // This row has over 200 no-null elements, so under the new fast paths the unstable `sort_lists`
+  // routes it through the packed-radix engine (its average list size is at/above the fast-sort
+  // cutoff); the comparison path (`stable_sort_lists`) sorts it directly. The EQUIVALENT assertions
+  // below tolerate the engine choice -- both reproduce the comparison sort's ordering.
   {
     // clang-format off
     LCW input{0.0, -0.0, -NaN, -NaN, NaN, Inf, -Inf,
@@ -341,5 +623,40 @@ TEST_F(SortListsDouble, InfinityAndNaN)
       generate_sorted_lists(cudf::lists_column_view{input}, {}, {});
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted_lists->view(), expected);
     CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted_lists->view(), expected);
+  }
+}
+
+// Floating-point NaN/Inf/signed-zero/denormal ordering through the tiered kernel (explicit
+// ASCENDING
+// + nulls-AFTER; the null-bearing rows route there, unlike InfinityAndNaN which uses the default
+// order and the comparison path). cudf orders -Inf < finite (incl. +/-0 and denormals) < +Inf < NaN
+// (every sign/payload, mutually equal, last); nulls follow NaN. Every NaN is canonicalized to the
+// all-ones key, so an un-canonicalized -NaN cannot sort near -Inf. EQUIVALENT since +/-0 and NaN
+// groups collapse. The thirteen-element FLOAT64 row (unsigned __int128 key) and the ten-element
+// FLOAT32 row (uint64 key) both land in the warp tier, covering both key widths; the network tier
+// (size <= TIERED_NETWORK_CAP == 8) is exercised by the tiny-segment tests.
+TEST_F(SortListsDouble, NumericPackedFloatNaNInfinity)
+{
+  {  // FLOAT64: the 8-byte unsigned __int128 tiered key; thirteen elements land in the warp tier.
+    auto constexpr NaN    = std::numeric_limits<double>::quiet_NaN();
+    auto constexpr Inf    = std::numeric_limits<double>::infinity();
+    auto constexpr denorm = std::numeric_limits<double>::denorm_min();
+    auto constexpr Max    = std::numeric_limits<double>::max();  // DBL_MAX boundary vs. Inf
+    using LCWd            = cudf::test::lists_column_wrapper<double>;
+    LCWd input{
+      {{NaN, -Inf, -0.0, 3.5, -NaN, Inf, 0.0, denorm, -2.0, 0.0, Inf, Max, -Max}, null_at(9)}};
+    LCWd expected{
+      {{-Inf, -Max, -2.0, -0.0, 0.0, denorm, 3.5, Max, Inf, Inf, NaN, -NaN, 0.0}, null_at(12)}};
+    expect_both_sort_paths_equivalent(cudf::lists_column_view{input}, expected);
+  }
+  {  // FLOAT32: the <= 4-byte uint64 tiered key; ten elements land in the warp tier.
+    auto constexpr NaN    = std::numeric_limits<float>::quiet_NaN();
+    auto constexpr Inf    = std::numeric_limits<float>::infinity();
+    auto constexpr denorm = std::numeric_limits<float>::denorm_min();
+    auto constexpr Max    = std::numeric_limits<float>::max();  // FLT_MAX boundary vs. Inf
+    using LCWf            = cudf::test::lists_column_wrapper<float>;
+    LCWf input{{{-NaN, Inf, -0.0f, 2.5f, -Inf, denorm, 0.0f, NaN, Max, -Max}, null_at(6)}};
+    LCWf expected{{{-Inf, -Max, -0.0f, denorm, 2.5f, Max, Inf, NaN, -NaN, 0.0f}, null_at(9)}};
+    expect_both_sort_paths_equivalent(cudf::lists_column_view{input}, expected);
   }
 }

--- a/cpp/tests/sort/segmented_sort_tests.cpp
+++ b/cpp/tests/sort/segmented_sort_tests.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2021-2025, NVIDIA CORPORATION.
+ * SPDX-FileCopyrightText: Copyright (c) 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -352,4 +352,104 @@ TEST_F(SegmentedSortInt, UnbalancedOffsets)
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view().column(0), expected->view().column(0));
   result = cudf::stable_segmented_sort_by_key(input_view, input_view, segments);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(result->view().column(0), expected->view().column(0));
+}
+
+// The unstable single-column explicit-order fast paths (tiered, packed-radix, and strings -- each
+// now folding any explicit (order, null_order) into its keys) label elements by dense segment
+// ordinal and index the output by raw offset, so they are correct only when the offsets span every
+// row `[0, num_rows]`. The public contract explicitly allows offsets that skip
+// leading/trailing rows (those rows stay unsorted) and single-index offsets (no rows sorted). The
+// offsets-coverage guard routes such non-normalized inputs to the comparison/CUB path instead.
+// These tests exercise that guard directly on the public API -- the same driver
+// `segmented_top_k_order` delegates into -- for each fast-path family; without the guard each
+// returns the wrong order (or, for a single index, shifts a packed key by 64 bits). `sort_lists`
+// always normalizes its offsets, so it is unaffected.
+
+// Partial-coverage offsets {3, 7} on a no-null INT32 column route to the tiered fast path when the
+// guard is absent; with the guard they take the comparison/CUB path, which sorts only [3, 7) and
+// leaves the out-of-segment rows in place.
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsNumeric)
+{
+  using T = int;
+  column_wrapper<T> col{{50, 51, 52, 40, 10, 30, 20, 57, 58, 59}};
+  column_wrapper<int> segments{{3, 7}};
+  cudf::table_view input{{col}};
+  // Rows 0-2 and 7-9 stay identity; [3, 7) = {40, 10, 30, 20} sorts ascending to {10, 20, 30, 40}.
+  column_wrapper<T> expected{{50, 51, 52, 10, 20, 30, 40, 57, 58, 59}};
+  auto result = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
+// One-sided partial coverage: each case satisfies exactly one half of the guard's
+// `first == 0 and last == num_rows` conjunction, so the halves are pinned independently (offsets
+// like {3, 7} violate both at once and cannot distinguish `and` from `or`). Rows outside the
+// offsets stay in place, per the public contract above.
+TEST_F(SegmentedSortInt, FastPathOneSidedOffsets)
+{
+  using T = int;
+  column_wrapper<T> col{{50, 51, 52, 40, 10, 30, 20, 57, 58, 59}};
+  cudf::table_view input{{col}};
+  {  // starts at 0, stops short: only [0, 7) sorts; rows 7-9 stay in place
+    column_wrapper<int> segments{{0, 7}};
+    column_wrapper<T> expected{{10, 20, 30, 40, 50, 51, 52, 57, 58, 59}};
+    auto result = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+  }
+  {  // skips leading rows, ends at num_rows: only [3, 10) sorts; rows 0-2 stay in place
+    column_wrapper<int> segments{{3, 10}};
+    column_wrapper<T> expected{{50, 51, 52, 10, 20, 30, 40, 57, 58, 59}};
+    auto result = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+  }
+}
+
+// Partial-coverage offsets on a no-null INT32 column whose average list size reaches the
+// packed-radix band: {100, 300} over 400 rows (average 200) would take the packed-radix fast path,
+// which globally sorts a permutation of [0, num_rows) and mislabels partial coverage. With the
+// guard it sorts only [100, 300).
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsPackedRadix)
+{
+  using T                 = int;
+  cudf::size_type const n = 400;
+  std::vector<T> vals(n);
+  std::vector<T> ex(n);
+  for (cudf::size_type i = 0; i < n; ++i) {
+    vals[i] = 1'000 - i;  // strictly descending, distinct
+    // [100, 300) sorts ascending (701..900); the rest stay identity.
+    ex[i] = (i < 100 or i >= 300) ? vals[i] : (701 + (i - 100));
+  }
+  column_wrapper<T> col(vals.begin(), vals.end());
+  column_wrapper<T> expected(ex.begin(), ex.end());
+  column_wrapper<int> segments{{100, 300}};
+  cudf::table_view input{{col}};
+  auto result = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
+// Single-index offsets (num_segments == 0) sort no values -- the documented contract. The guard
+// requires at least two offsets, so these fall through to the comparison/CUB path (which treats
+// zero segments as identity) rather than a fast path whose zero-width segment field would shift a
+// 64-bit packed key by 64 (undefined behavior). Covers a fixed-width and a STRING column.
+TEST_F(SegmentedSortInt, FastPathSingleIndexOffsets)
+{
+  column_wrapper<int> segments{{5}};  // one index -> num_segments == 0 -> no values sorted
+  {
+    using T = int;
+    column_wrapper<T> col{{50, 40, 30, 20, 10, 90, 80, 70, 60, 55}};
+    cudf::table_view input{{col}};
+    auto result = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), input);  // unchanged: no values sorted
+  }
+  {
+    cudf::test::strings_column_wrapper col{"e", "d", "c", "b", "a", "j", "i", "h", "g", "f"};
+    auto const input = cudf::table_view{{col}};
+    auto result      = cudf::segmented_sort_by_key(
+      input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+    CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), input);  // unchanged: no values sorted
+  }
 }


### PR DESCRIPTION
cudf::lists::sort_lists and segmented_sort_by_key route every fixed-width sort through either CUB DeviceSegmentedSort (no-null integrals in a small band) or the generic comparator, so long lists and null-bearing columns pay a cardinality-scaled comparator cost. Add the numeric packed-radix engine: numeric_packed_key_builder packs (segment ordinal, validity class, order-mapped value) into one radix key so a single global cub::DeviceRadixSort pass reproduces the comparison order via fast_segmented_sorted_order_numeric_packed, and choose_fixed_width_sort_path routes null-bearing columns (validity folds into the key) and long lists (average list size of at least 100) to it. The engine lives in the new TU segmented_sort_fixed_width.cu with shared key primitives in segmented_sort_keys.cuh and declarations in segmented_sort_fast.cuh.

The fast-path gate engages only for a single explicit ascending / nulls-after key column whose offsets cover all rows; fast_path_offsets_cover_all_rows fences the zero-width segment-field shift. Other polarities, DECIMAL128, and the short no-null band keep their existing routing, and the sort_polarity key machinery ships in its general form while being constructed at the identity polarity only.

Benchmarked against the previous commit on sort_list_of_numbers: null-bearing cells reach a 3.3x geomean and long-list no-null cells 3.7x (up to 5.2x) across INT32/INT64/FLOAT32/FLOAT64, with cells outside the gate unchanged apart from the offsets-coverage probe on tiny lists. New tests cover negatives and bounds, NaN and infinity ordering, timestamps, empty and single rows, the average-100 gate boundary, and partial-offsets guards; the LISTS and SORT suites are green.

---

**Stacked series — part 2/7, decomposing rapidsai/cudf#23101 into reviewable steps.** Stacked on #75 (base branch `improve-list-sort-01-bench`).

**compute-sanitizer:** memcheck + racecheck (`--rmm-mode=cuda`) over `LISTS_TEST` (`SortLists*`, 44 tests) and `SORT_TEST` (`SegmentedSort*`, 55 tests) — **0 errors, 0 hazards**.
