### PR TITLE
Add tiered segmented-sort engine (3/7)

### DIFF
--- a/cpp/benchmarks/sort/sort_list_of_numbers.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_numbers.cpp
@@ -21,13 +21,15 @@
 
 // Benchmark for cudf::lists::sort_lists on a LIST<numeric> column -- the operation Spark array_sort
 // lowers to. The type axis spans the integral, floating-point, and decimal128 fixed-width paths.
-// For an explicit ascending / nulls-after sort, an integral or floating-point column now takes the
-// global packed-radix path when it carries nulls or its average list size reaches 100; the short
-// no-null remainder keeps CUB DeviceSegmentedSort (integral) or the comparator fallback (floating
-// point). DECIMAL128 and every other (order, null_order) combination keep the base routing: CUB
-// for eligible no-null integrals, otherwise the lexicographic comparator over a prepended
-// segment-id column. The shape axes bracket those boundaries; cells outside ascending /
-// nulls-after measure the base paths.
+// For an explicit ascending / nulls-after sort, the shape axes straddle the fast-path routing's
+// measured crossovers: max_list_size 4 gives tiny lists, which the tiered network / warp tiers
+// claim; 32 the mid-size band the tiered kernel also claims; and 256 the long-list band the packed
+// radix claims. null_frequency 0.1 injects element-level (leaf) nulls, which route every supported
+// column to the tiered kernel (it orders nulls last in-register / in-warp), racing the comparison
+// sort the nullable case would otherwise use; 0 exercises the no-null routing that also weighs the
+// packed radix. DECIMAL128 and every other (order, null_order) combination keep the base routing:
+// CUB for eligible no-null integrals, otherwise the lexicographic comparator over a prepended
+// segment-id column.
 template <typename Type>
 void bench_sort_list_of_numbers(nvbench::state& state, nvbench::type_list<Type>)
 {
@@ -93,13 +95,13 @@ NVBENCH_BENCH_TYPES(
     nvbench::type_list<std::int32_t, std::int64_t, float, double, numeric::decimal128>))
   .set_name("sort_list_of_numbers")
   .add_int64_axis("num_rows", {100'000, 1'000'000})
-  // 4 and 32 keep no-null cells below the packed-radix average gate (100); 256 (average ~128)
-  // crosses it, routing eligible ascending / nulls-after cells to the packed radix.
+  // 4 keeps lists tiny (the tiered network/warp tiers claim them); 32 is the mid band the tiered
+  // kernel also claims; 256 pushes the average past the packed-radix cutoff.
   .add_int64_axis("max_list_size", {4, 32, 256})
-  // No-null vs a realistic null rate; nulls route eligible ascending / nulls-after cells to the
-  // packed radix (validity folds into its key) and leave every other combination on its base path.
+  // No-null vs a realistic null rate; the null-bearing ascending / nulls-after cells route to the
+  // tiered kernel (nulls ordered last in-register / in-warp).
   .add_float64_axis("null_frequency", {0, 0.1})
-  // Full (order, null_order) matrix: the packed-radix gate engages only for explicit ascending /
+  // Full (order, null_order) matrix: the fast-path gate engages only for explicit ascending /
   // nulls-after; the other combinations measure the base routing.
   .add_string_axis("order", {"ASC", "DESC"})
   .add_string_axis("null_order", {"AFTER", "BEFORE"});

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -86,6 +86,35 @@ fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
                                                    rmm::cuda_stream_view stream);
 
 /**
+ * @brief Faster segmented sorted-order for a single fixed-width key column via a tiered sort
+ *
+ * Classifies segments by size into three tiers whose cost tracks the segment size rather than the
+ * key width -- the win over the packed-radix path when segments are tiny but values are wide: a
+ * segment of
+ * <= `TIERED_NETWORK_CAP` elements is sorted by one thread with a fixed Batcher network, a segment
+ * of
+ * <= `TIERED_WARP_CAP` by a full warp with `cub::WarpMergeSort`, and a rare radix-tier outlier by a
+ * packed radix over just that segment's elements (scattered into place). Nulls are ordered on the
+ * polarity's side within each segment by a three-valued class flag in the sort key, and a
+ * descending order complements the key's value bits; the result is the same order the comparison
+ * path produces. Engages for any explicit (order, null_order), which the caller resolves into
+ * `polarity`; handles both nullable and non-nullable columns.
+ *
+ * @param input The fixed-width column whose elements are sorted within each segment
+ * @param segment_offsets Identifies the segments to sort within
+ * @param polarity Key polarity resolved from the requested (order, null_order)
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return Indices that map the column to a segmented sorted order
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_tiered(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
+/**
  * @brief Faster segmented sorted-order for a single fixed-width key column via one radix sort
  *
  * Replaces the comparison sort (used for null-bearing or large columns) and

--- a/cpp/src/sort/segmented_sort_fixed_width.cu
+++ b/cpp/src/sort/segmented_sort_fixed_width.cu
@@ -5,12 +5,17 @@
 
 #include "segmented_sort_fast.cuh"
 #include "segmented_sort_keys.cuh"
+#include "segmented_sort_warp_kernel.cuh"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/detail/utilities/assert.cuh>
+#include <cudf/detail/utilities/grid_1d.cuh>
+#include <cudf/detail/utilities/vector_factories.hpp>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
+#include <cudf/utilities/span.hpp>
 #include <cudf/utilities/traits.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
@@ -19,7 +24,10 @@
 #include <rmm/device_uvector.hpp>
 #include <rmm/exec_policy.hpp>
 
+#include <cub/device/device_partition.cuh>
 #include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_select.cuh>
+#include <cub/warp/warp_merge_sort.cuh>
 #include <cuda/iterator>
 #include <cuda/std/algorithm>
 #include <cuda/std/bit>
@@ -27,6 +35,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
+#include <thrust/scatter.h>
 #include <thrust/sequence.h>
 #include <thrust/transform.h>
 
@@ -101,6 +110,22 @@ __device__ inline cuda::std::uint64_t radix_encode_u64(T value)
     }
     return static_cast<cuda::std::uint64_t>(encoded);
   }
+}
+
+/**
+ * @brief The sixteen-byte analogue of `radix_encode_u64`: the order-preserving 128-bit encoding
+ *
+ * Only reached for the `DECIMAL128` storage rep (`__int128_t`), which is always signed, so the sign
+ * bit of the 128-bit two's-complement pattern is flipped unconditionally -- the 128-bit form of the
+ * same order-preserving transform the narrower encoders apply. Fixed-point reps carry one
+ * column-wide scale, so ordering by the rep equals value order.
+ */
+template <typename T>
+__device__ inline unsigned __int128 radix_encode_u128(T value)
+{
+  auto encoded = static_cast<unsigned __int128>(value);
+  encoded ^= (static_cast<unsigned __int128>(1) << 127);
+  return encoded;
 }
 
 /**
@@ -349,6 +374,1032 @@ inline bool is_numeric_packed_radix_supported(data_type type)
          cudf::is_floating_point(type) or cudf::is_chrono(type);
 }
 
+// ==========================================================================================
+// Tiered per-segment sort for a single fixed-width key column.
+//
+// The packed-radix path pays a fixed per-element cost (a global radix over a key as wide as the
+// value) that dominates when segments are tiny -- the LIST<DECIMAL128> / small-int regime where the
+// value is wide but each segment holds only a handful of elements. This path instead classifies
+// segments by size into three tiers, each sorting at a cost that tracks the segment size rather
+// than the key width: a segment of <= `TIERED_NETWORK_CAP` elements is sorted by one thread with a
+// fixed sorting network held entirely in registers; a segment of <= `TIERED_WARP_CAP` by a full
+// warp with `cub::WarpMergeSort`; and a rare large outlier by a packed radix restricted to just
+// that segment's elements. Nulls sort on the polarity's side within a segment via a three-valued
+// class flag folded into the key, and a descending order complements the key's value bits. Engages
+// for any explicit (order, null_order) / unstable on the fixed-width reps
+// `is_tiered_sort_supported` admits (the caller resolves the polarity); handles both nullable and
+// non-nullable columns.
+// ==========================================================================================
+
+/**
+ * @brief Ordering key for the sixteen-byte (DECIMAL128) tiered path: a class flag over a 128-bit
+ * value
+ *
+ * `flag` dominates the order, placing the polarity's element classes below the pad as
+ * `tiered_element_class` requires; within the valid class `hi` then `lo` -- the sign-flipped
+ * 128-bit value split most- then least-significant, complemented when descending -- give
+ * unsigned-compare == the requested value order. Three fields pack to 24 bytes (a uint32 flag
+ * beside two uint64 words), the width the warp tier's register / shared budget is sized against; a
+ * null or pad leaves the value words zero and unread.
+ */
+struct tiered_key128 {
+  cuda::std::uint64_t hi;
+  cuda::std::uint64_t lo;
+  cuda::std::uint32_t flag;
+};
+static_assert(sizeof(tiered_key128) == 24 and alignof(tiered_key128) == 8,
+              "tiered_key128 must stay 24 bytes with 8-byte alignment");
+
+/**
+ * @brief Maps a tiered storage type to its packed ordering key by value width
+ *
+ * The class flag rides the high bits so a native (unsigned / lexicographic) compare orders valid <
+ * null < pad and then by value. A value of four bytes or fewer packs into a `uint64` (flag in bits
+ * 32-33), an eight-byte value into an `unsigned __int128` (flag in bits 64-65), and the
+ * sixteen-byte DECIMAL128 rep into the 24-byte `tiered_key128`. Selection is by `sizeof(T)`, so
+ * every supported rep
+ * -- int32 / int64, float / double, the int32 / int64-rep timestamps and durations, and the
+ * DECIMAL128
+ * `__int128` rep -- maps to the key of its width; the value bits are produced by the
+ * `radix_encode_*` of the matching width, which carries the float (NaN / sign) and chrono
+ * (rep-extract) transforms.
+ */
+template <typename T>
+using tiered_key_t = cuda::std::conditional_t<
+  sizeof(T) <= 4,
+  cuda::std::uint64_t,
+  cuda::std::conditional_t<sizeof(T) == 8, unsigned __int128, tiered_key128>>;
+
+/**
+ * @brief The pad key for type `T`: the class flag set to `tier_pad`, value words zero
+ *
+ * Ordered strictly after every valid element and null under the native / `operator<` compare, so
+ * the network and `WarpMergeSort` keep the pad slots beyond a segment's valid-item boundary. Host-
+ * and device-usable because the launch code builds it on the host and passes it to the kernel by
+ * value.
+ */
+template <typename T>
+__host__ __device__ inline tiered_key_t<T> tiered_pad_key()
+{
+  using KeyT = tiered_key_t<T>;
+  if constexpr (cuda::std::is_same_v<KeyT, tiered_key128>) {
+    return tiered_key128{0, 0, tier_pad};
+  } else if constexpr (cuda::std::is_same_v<KeyT, unsigned __int128>) {
+    return static_cast<unsigned __int128>(tier_pad) << 64;
+  } else {
+    return static_cast<cuda::std::uint64_t>(tier_pad) << 32;
+  }
+}
+
+/**
+ * @brief Strict-weak less-than over any tiered key: native `<` for the packed integer keys,
+ * `tiered_key128::operator<` for the DECIMAL128 key. Comparator-generic, as the network and
+ * `cub::WarpMergeSort` want.
+ */
+struct tiered_key_less {
+  template <typename KeyT>
+  __device__ bool operator()(KeyT const& a, KeyT const& b) const
+  {
+    return a < b;
+  }
+};
+
+/**
+ * @brief Builds the packed tiered key for one element: class flag then radix-encoded value
+ *
+ * The polarity's `element_class` assigns the null and valid classes (0/1) so a null -- its value
+ * left zero and unread -- sorts on the requested side of every valid element in its segment
+ * regardless of that element's value; a valid element carries its value through the same
+ * order-preserving `radix_encode_*` the packed-radix path uses, complemented within the value bits
+ * when descending (for the 128-bit key, complementing each word complements the whole value, and
+ * the hi-then-lo compare equals the 128-bit unsigned compare), so an unsigned compare of the key
+ * reproduces the requested value order. The complement never reaches the class flag: it is
+ * confined to the value field below (or, for `tiered_key128`, to the separate value words).
+ */
+template <typename T>
+struct tiered_key_builder {
+  column_device_view d_input;
+  bool has_nulls;
+  sort_polarity polarity;
+  __device__ tiered_key_t<T> operator()(size_type idx) const
+  {
+    using KeyT     = tiered_key_t<T>;
+    bool const nul = has_nulls && d_input.is_null(idx);
+    auto const cls = polarity.element_class(nul);
+    if constexpr (cuda::std::is_same_v<KeyT, tiered_key128>) {
+      if (nul) { return tiered_key128{0, 0, cls}; }
+      auto const encoded = radix_encode_u128<T>(d_input.element<T>(idx));
+      auto const mask    = polarity.value_mask64();
+      return tiered_key128{static_cast<cuda::std::uint64_t>(encoded >> 64) ^ mask,
+                           static_cast<cuda::std::uint64_t>(encoded) ^ mask,
+                           cls};
+    } else if constexpr (cuda::std::is_same_v<KeyT, unsigned __int128>) {
+      if (nul) { return static_cast<unsigned __int128>(cls) << 64; }
+      return (static_cast<unsigned __int128>(cls) << 64) |
+             static_cast<unsigned __int128>(radix_encode_u64<T>(d_input.element<T>(idx)) ^
+                                            polarity.value_mask64());
+    } else {
+      if (nul) { return static_cast<cuda::std::uint64_t>(cls) << 32; }
+      return (static_cast<cuda::std::uint64_t>(cls) << 32) |
+             static_cast<cuda::std::uint64_t>(radix_encode_u32<T>(d_input.element<T>(idx)) ^
+                                              polarity.value_mask32());
+    }
+  }
+};
+
+// Network tier: one thread sorts a whole segment of <= `TIERED_NETWORK_CAP` elements with a fixed
+// Batcher odd-even mergesort network, entirely in registers -- no shared memory, no warp
+// cooperation. The 19-comparator network for eight keys sorts every one of the 2^8 binary inputs,
+// so by the zero-one principle it sorts any totally-ordered keys, including the three-valued (flag,
+// value) key. The widest key is 24 bytes, so a thread holds at most eight keys and eight indices in
+// registers, which fits without spilling.
+constexpr size_type TIERED_NETWORK_CAP = 8;
+// The network kernel unrolls a fixed 19-comparator Batcher network over exactly eight register
+// slots: raising the cap would leave slots the network never orders (silent mis-sort), lowering it
+// would index past the register arrays. Regenerate the network before changing the cap.
+static_assert(TIERED_NETWORK_CAP == 8,
+              "tiered_network_sort_kernel hardcodes the eight-key Batcher network");
+// Warp tier: a full 32-lane warp sorts a segment of <= `TIERED_WARP_CAP` elements with
+// `cub::WarpMergeSort` at two items per lane. One 32*2 = 64 tile covers the class for every
+// supported key width -- the register and shared budget stays comfortable even for the widest key
+// -- so the cap is uniform rather than shrinking with the key width as a wider tile would force. A
+// 128-thread block hosts four warp-segments.
+constexpr int TIERED_WARP_LANES     = 32;
+constexpr int TIERED_WARP_ITEMS     = 2;
+constexpr size_type TIERED_WARP_CAP = TIERED_WARP_LANES * TIERED_WARP_ITEMS;  // 64
+
+/**
+ * @brief Selects segments whose size is <= `cap` (the network tier) for `cub::DevicePartition::If`
+ */
+struct segment_in_network_tier {
+  size_type const* d_offsets;
+  size_type cap;
+  __device__ bool operator()(size_type seg) const
+  {
+    return (d_offsets[seg + 1] - d_offsets[seg]) <= cap;
+  }
+};
+
+/**
+ * @brief Selects segments whose size is in `(network_cap, warp_cap]` (the warp tier)
+ *
+ * The explicit lower bound keeps the predicate correct whether `DevicePartition::If` evaluates the
+ * second selector on all items or only those the first selector rejected; segments above `warp_cap`
+ * match neither selector and land in the unselected (radix-tier) partition.
+ */
+struct segment_in_warp_tier {
+  size_type const* d_offsets;
+  size_type network_cap;
+  size_type warp_cap;
+  __device__ bool operator()(size_type seg) const
+  {
+    auto const sz = d_offsets[seg + 1] - d_offsets[seg];
+    return sz > network_cap && sz <= warp_cap;
+  }
+};
+
+/**
+ * @brief Selects elements whose segment is in the radix tier (size > `warp_cap`) for
+ * `cub::DeviceSelect::If`
+ *
+ * Applied to a counting iterator over element indices, so it compacts the global indices of exactly
+ * the radix-tier segments' elements -- and, because it scans in ascending index order, they come
+ * out grouped by segment then by within-segment position, the arrangement
+ * `radix_sort_large_segments` relies on to scatter each sorted element to its output slot.
+ */
+struct element_in_radix_tier {
+  size_type const* d_segment_ids;
+  size_type const* d_offsets;
+  size_type warp_cap;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const seg = d_segment_ids[i];
+    return (d_offsets[seg + 1] - d_offsets[seg]) > warp_cap;
+  }
+};
+
+/**
+ * @brief One compare-exchange of a sorting network: orders `keys[a] <= keys[b]` under `cmp`,
+ * carrying each key's paired value with it. `cmp(keys[b], keys[a])` is true exactly when the pair
+ * is inverted.
+ */
+template <typename KeyT, typename CompareOp>
+__device__ inline void network_compare_exchange(
+  KeyT* keys, size_type* vals, int a, int b, CompareOp cmp)
+{
+  if (cmp(keys[b], keys[a])) {
+    KeyT const tk      = keys[a];
+    keys[a]            = keys[b];
+    keys[b]            = tk;
+    size_type const tv = vals[a];
+    vals[a]            = vals[b];
+    vals[b]            = tv;
+  }
+}
+
+/**
+ * @brief Sorts one segment of <= `TIERED_NETWORK_CAP` elements per thread with a fixed
+ * 19-comparator Batcher network
+ *
+ * Thread `t` owns segment `d_seg_list[t]`, loads its <= 8 elements' keys and global indices into
+ * registers, fills the unused slots past the segment size with the pad key (which sorts after every
+ * valid element and null), applies the network, then writes the sorted global indices back to
+ * `[seg_start, seg_start + seg_size)`. The network sorts every one of the 2^8 binary inputs, so by
+ * the zero-one principle it sorts the three-valued (flag, value) key for any values; the pads
+ * settle into the top `8 - seg_size` slots and are never written back. Purely register-resident --
+ * no shared memory and no warp cooperation -- so a segment's cost is independent of its
+ * neighbours'.
+ *
+ * A function template so the two translation units that include this header (segmented_sort.cu and
+ * stable_segmented_sort.cu) instantiate it only where used -- the STABLE unit never does, avoiding
+ * an unused `static` kernel under -Werror.
+ */
+template <typename T, int BLOCK_THREADS, typename CompareOp>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_network_sort_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  bool has_nulls,
+  sort_polarity polarity,
+  size_type* d_out,
+  CompareOp compare_op,
+  tiered_key_t<T> pad_key)
+{
+  using KeyT     = tiered_key_t<T>;
+  auto const tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  if (tid >= static_cast<thread_index_type>(num_class_segments)) { return; }
+
+  auto const seg       = d_seg_list[tid];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+
+  tiered_key_builder<T> const build_key{d_input, has_nulls, polarity};
+  KeyT keys[TIERED_NETWORK_CAP];
+  size_type vals[TIERED_NETWORK_CAP];
+#pragma unroll
+  for (int i = 0; i < TIERED_NETWORK_CAP; ++i) {
+    if (i < seg_size) {
+      auto const gidx = seg_start + i;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  // Batcher odd-even mergesort for 8 keys (19 compare-exchanges). Each orders its lower index <=
+  // its higher, so the pads settle above every real element and [0, seg_size) ends up sorted in the
+  // key order the polarity encodes: the requested value order with nulls on their configured side.
+  network_compare_exchange(keys, vals, 0, 1, compare_op);
+  network_compare_exchange(keys, vals, 2, 3, compare_op);
+  network_compare_exchange(keys, vals, 4, 5, compare_op);
+  network_compare_exchange(keys, vals, 6, 7, compare_op);
+  network_compare_exchange(keys, vals, 0, 2, compare_op);
+  network_compare_exchange(keys, vals, 1, 3, compare_op);
+  network_compare_exchange(keys, vals, 4, 6, compare_op);
+  network_compare_exchange(keys, vals, 5, 7, compare_op);
+  network_compare_exchange(keys, vals, 1, 2, compare_op);
+  network_compare_exchange(keys, vals, 5, 6, compare_op);
+  network_compare_exchange(keys, vals, 0, 4, compare_op);
+  network_compare_exchange(keys, vals, 3, 7, compare_op);
+  network_compare_exchange(keys, vals, 1, 5, compare_op);
+  network_compare_exchange(keys, vals, 2, 6, compare_op);
+  network_compare_exchange(keys, vals, 1, 4, compare_op);
+  network_compare_exchange(keys, vals, 3, 6, compare_op);
+  network_compare_exchange(keys, vals, 2, 4, compare_op);
+  network_compare_exchange(keys, vals, 3, 5, compare_op);
+  network_compare_exchange(keys, vals, 3, 4, compare_op);
+
+#pragma unroll
+  for (int i = 0; i < TIERED_NETWORK_CAP; ++i) {
+    if (i < seg_size) { d_out[seg_start + i] = vals[i]; }
+  }
+}
+
+/**
+ * @brief Sorts one segment per virtual warp with `cub::WarpMergeSort` under a null-aware comparator
+ *
+ * Each virtual warp of `W` lanes owns one segment index from `d_seg_list` (a single size class).
+ * Lane `l` holds items `[l*IPT, l*IPT+IPT)` of the segment in blocked order -- the arrangement
+ * `BlockMergeSortStrategy` expects -- with slots past the segment's real size filled with the pad
+ * key. The `valid_items = seg_size` boundary and that pad key make `WarpMergeSort` keep the real
+ * elements -- in the polarity's key order -- in `[0, seg_size)` and the pads beyond it, so writing
+ * back only `[0, seg_size)` yields the segment's sorted order. The sorted values -- global element
+ * indices -- go straight into the output gather map at the segment's slots. `W*IPT` must be >= the
+ * class's maximum segment size, guaranteed by the caps the caller partitions on.
+ *
+ * A function template for the same reason as `tiered_network_sort_kernel`: the STABLE translation
+ * unit must not instantiate an unused `static` kernel under -Werror.
+ */
+template <typename T, int W, int IPT, int BLOCK_THREADS, typename CompareOp>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_warp_sort_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  bool has_nulls,
+  sort_polarity polarity,
+  size_type* d_out,
+  CompareOp compare_op,
+  tiered_key_t<T> pad_key)
+{
+  using KeyT                     = tiered_key_t<T>;
+  using WarpMergeSortT           = cub::WarpMergeSort<KeyT, IPT, W, size_type>;
+  constexpr int VWARPS_PER_BLOCK = BLOCK_THREADS / W;
+  __shared__ typename WarpMergeSortT::TempStorage temp_storage[VWARPS_PER_BLOCK];
+
+  auto const global_tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  auto const vwarp_id   = static_cast<size_type>(global_tid / W);  // the class segment to sort
+  auto const lane       = static_cast<int>(threadIdx.x % W);  // logical lane in the virtual warp
+  auto const vwarp_slot = static_cast<int>(threadIdx.x / W);  // virtual warp's shared-mem slot
+  // `vwarp_id` is identical across a virtual warp's W lanes, so the whole virtual warp returns
+  // together and never desynchronizes the `__syncwarp(member_mask)` inside WarpMergeSort::Sort.
+  if (vwarp_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[vwarp_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+
+  tiered_key_builder<T> const build_key{d_input, has_nulls, polarity};
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  WarpMergeSortT(temp_storage[vwarp_slot])
+    .Sort(keys, vals, compare_op, static_cast<int>(seg_size), pad_key);
+
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+// The warp tier routes a no-null INT32 / INT64 segment to a kernel measured faster than the packed
+// `WarpMergeSort`: the value alone (no null field) fits a raw key half the packed key's width,
+// cutting the sort's data traffic. INT32 (and the low sub-band of INT64) uses a register
+// shuffle-bitonic; the high sub-band of INT64 a `WarpMergeSort` over that raw key. A null-bearing
+// column keeps the packed three-valued key (a raw key cannot express null-ordering), so these apply
+// only when `has_nulls` is false, guaranteed by the caller before a raw-key band launches.
+
+/**
+ * @brief Raw ordering key for the no-null warp tier: the order-preserving value alone, no null
+ * field
+ *
+ * Four-byte-or-narrower values pack into a `uint32`, eight-byte into a `uint64` -- half the packed
+ * `tiered_key_t` width at each, since a no-null segment needs no class flag. The `radix_encode_*`
+ * of the matching width carries the same value transform the packed key uses, complemented when
+ * descending, so an unsigned compare reproduces the requested value order.
+ */
+template <typename T>
+using tiered_raw_key_t =
+  cuda::std::conditional_t<sizeof(T) <= 4, cuda::std::uint32_t, cuda::std::uint64_t>;
+
+/**
+ * @brief Builds the raw no-null key for one element: its order-preserving encoded value,
+ * complemented when descending
+ */
+template <typename T>
+struct tiered_raw_key_builder {
+  column_device_view d_input;
+  sort_polarity polarity;
+  __device__ tiered_raw_key_t<T> operator()(size_type idx) const
+  {
+    if constexpr (sizeof(T) <= 4) {
+      return radix_encode_u32<T>(d_input.element<T>(idx)) ^ polarity.value_mask32();
+    } else {
+      return radix_encode_u64<T>(d_input.element<T>(idx)) ^ polarity.value_mask64();
+    }
+  }
+};
+
+/**
+ * @brief The pad key for the raw no-null path: the maximum unsigned value, ordered after every real
+ * element. A real element can encode to this same maximum (an `INT*_MAX` value ascending, or the
+ * minimum under the descending complement), so the warp band uses the stability-guaranteed
+ * `StableSort`: reals hold lower tile indices than pads, and a stable sort keeps an equal-valued
+ * real ahead of the pads -- inside the valid range -- so no real element is dropped for a pad.
+ */
+template <typename T>
+__host__ __device__ inline tiered_raw_key_t<T> tiered_raw_pad_key()
+{
+  return cuda::std::numeric_limits<tiered_raw_key_t<T>>::max();
+}
+
+/// Plain ascending less-than for the raw key -- no class flag, since the raw path is no-null only.
+struct tiered_raw_less {
+  template <typename KeyT>
+  __device__ bool operator()(KeyT const& a, KeyT const& b) const
+  {
+    return a < b;
+  }
+};
+
+/**
+ * @brief Ascending compare of a raw-key/index pair with a pad tie-break for the register bitonic
+ *
+ * Compares `(key, is_pad)` where `is_pad == (val < 0)`: a pad carries `val = -1`, a real element
+ * its non-negative global index. Ordering a real before a pad on equal keys keeps every real within
+ * `[0, seg_size)` after the sort even when a real key equals the maximum pad sentinel (the
+ * `INT*_MAX` element ascending, or the minimum element under the descending complement -- either
+ * encodes to all-ones), so the write-back never drops it or emits a pad slot.
+ */
+template <typename KeyT>
+__device__ inline bool bitonic_pad_less(KeyT ka, size_type va, KeyT kb, size_type vb)
+{
+  if (ka != kb) { return ka < kb; }
+  return (va >= 0) && (vb < 0);
+}
+
+/**
+ * @brief Clean-room register shuffle-bitonic sort of `W * IPT` elements across a logical warp
+ *
+ * The standard public-domain Batcher bitonic network (compile-time bounds unroll it to
+ * straight-line code). Blocked layout: element index `e = lane * IPT + item`. Intra-lane
+ * compare-exchanges
+ * (`j < IPT`) run in registers; inter-lane ones (`j >= IPT`) exchange with lane `lane ^ (j / IPT)`
+ * via `__shfl_xor_sync` confined to the logical warp by `mask` and width `W`. Each bitonic stage's
+ * direction is `(e & k) == 0` (ascending) and the low index of a pair is the one with the `j` bit
+ * clear, so each thread keeps the min or max consistently with its partner. The `(key, is_pad)`
+ * compare orders pads (max key, negative index) after every real element. Validated exhaustively on
+ * the host (zero-one principle) for the instantiated shapes.
+ */
+template <int W, int IPT, typename KeyT>
+__device__ inline void bitonic_warp_sort(KeyT (&keys)[IPT],
+                                         size_type (&vals)[IPT],
+                                         int lane,
+                                         unsigned mask)
+{
+  constexpr int n = W * IPT;
+  for (int k = 2; k <= n; k <<= 1) {
+    for (int j = k >> 1; j > 0; j >>= 1) {
+      if (j >= IPT) {
+        int const jl = j / IPT;
+#pragma unroll
+        for (int m = 0; m < IPT; ++m) {
+          int const e          = lane * IPT + m;
+          KeyT const pk        = __shfl_xor_sync(mask, keys[m], jl, W);
+          size_type const pv   = __shfl_xor_sync(mask, vals[m], jl, W);
+          bool const ascending = ((e & k) == 0);
+          bool const keep_min  = (((e & j) == 0) == ascending);
+          bool const take      = keep_min ? bitonic_pad_less(pk, pv, keys[m], vals[m])
+                                          : bitonic_pad_less(keys[m], vals[m], pk, pv);
+          if (take) {
+            keys[m] = pk;
+            vals[m] = pv;
+          }
+        }
+      } else {
+#pragma unroll
+        for (int m = 0; m < IPT; ++m) {
+          int const m2 = m ^ j;
+          if (m2 > m) {
+            int const e          = lane * IPT + m;
+            bool const ascending = ((e & k) == 0);
+            bool const inverted  = ascending
+                                     ? bitonic_pad_less(keys[m2], vals[m2], keys[m], vals[m])
+                                     : bitonic_pad_less(keys[m], vals[m], keys[m2], vals[m2]);
+            if (inverted) {
+              KeyT const tk      = keys[m];
+              keys[m]            = keys[m2];
+              keys[m2]           = tk;
+              size_type const tv = vals[m];
+              vals[m]            = vals[m2];
+              vals[m2]           = tv;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief Register shuffle-bitonic warp kernel over a segment-size band (raw keys, no-null case)
+ *
+ * One logical warp of `W` lanes sorts one segment of `<= W * IPT` elements whose size is in
+ * `(band_lo, band_hi]`; slots past the segment are pads (max key, index -1) that the `(key,
+ * is_pad)` tie-break keeps beyond `[0, seg_size)`. Template for the same -Werror reason as the
+ * other tiered kernels.
+ */
+template <typename T, int W, int IPT, int BLOCK_THREADS>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_bitonic_band_kernel(
+  column_device_view const d_input,
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  size_type band_lo,
+  size_type band_hi,
+  sort_polarity polarity,
+  size_type* d_out)
+{
+  using KeyT            = tiered_raw_key_t<T>;
+  auto const global_tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  auto const vwarp_id   = static_cast<size_type>(global_tid / W);
+  auto const lane       = static_cast<int>(threadIdx.x % W);
+  if (vwarp_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[vwarp_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+  if (seg_size <= band_lo || seg_size > band_hi) { return; }
+  // The register tile holds W*IPT elements; a band_hi above that would silently drop elements.
+  cudf_assert(seg_size <= W * IPT && "band segment exceeds the register tile (band_hi > W*IPT)");
+
+  tiered_raw_key_builder<T> const build_key{d_input, polarity};
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = tiered_raw_pad_key<T>();
+      vals[i] = size_type{-1};
+    }
+  }
+  // Member mask of this virtual warp's W physical lanes (W <= 16 here, so the shift is
+  // well-defined).
+  unsigned const mask = ((1u << W) - 1u) << ((static_cast<unsigned>(threadIdx.x) % 32u / W) * W);
+  bitonic_warp_sort<W, IPT>(keys, vals, lane, mask);
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+/// Launches one packed-key `WarpMergeSort` band over the shared warp-segment list (all tiered
+/// types)
+template <typename T, int W, int IPT>
+void launch_packed_warp_band(column_device_view const& d_input,
+                             size_type const* d_offsets,
+                             size_type const* d_warp_segs,
+                             size_type num_warp,
+                             bool has_nulls,
+                             sort_polarity polarity,
+                             size_type band_lo,
+                             size_type band_hi,
+                             size_type* d_out,
+                             rmm::cuda_stream_view stream)
+{
+  if (num_warp == 0) { return; }
+  using KeyT = tiered_key_t<T>;
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_warp) * W, TIERED_BLOCK_THREADS);
+  tiered_warp_band_kernel<KeyT,
+                          tiered_key_builder<T>,
+                          W,
+                          IPT,
+                          TIERED_BLOCK_THREADS,
+                          tiered_key_less>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      d_offsets,
+      d_warp_segs,
+      num_warp,
+      band_lo,
+      band_hi,
+      tiered_key_builder<T>{d_input, has_nulls, polarity},
+      d_out,
+      tiered_key_less{},
+      tiered_pad_key<T>());
+  CUDF_CHECK_CUDA(stream.value());
+}
+
+/// Launches one raw-key `WarpMergeSort` band over the shared warp-segment list (no-null only)
+template <typename T, int W, int IPT>
+void launch_raw_warp_band(column_device_view const& d_input,
+                          size_type const* d_offsets,
+                          size_type const* d_warp_segs,
+                          size_type num_warp,
+                          sort_polarity polarity,
+                          size_type band_lo,
+                          size_type band_hi,
+                          size_type* d_out,
+                          rmm::cuda_stream_view stream)
+{
+  if (num_warp == 0) { return; }
+  using KeyT = tiered_raw_key_t<T>;
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_warp) * W, TIERED_BLOCK_THREADS);
+  tiered_warp_band_kernel<KeyT,
+                          tiered_raw_key_builder<T>,
+                          W,
+                          IPT,
+                          TIERED_BLOCK_THREADS,
+                          tiered_raw_less>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      d_offsets,
+      d_warp_segs,
+      num_warp,
+      band_lo,
+      band_hi,
+      tiered_raw_key_builder<T>{d_input, polarity},
+      d_out,
+      tiered_raw_less{},
+      tiered_raw_pad_key<T>());
+  CUDF_CHECK_CUDA(stream.value());
+}
+
+/// Launches one register-bitonic band over the shared warp-segment list (raw keys, no-null only)
+template <typename T, int W, int IPT>
+void launch_bitonic_band(column_device_view const& d_input,
+                         size_type const* d_offsets,
+                         size_type const* d_warp_segs,
+                         size_type num_warp,
+                         sort_polarity polarity,
+                         size_type band_lo,
+                         size_type band_hi,
+                         size_type* d_out,
+                         rmm::cuda_stream_view stream)
+{
+  if (num_warp == 0) { return; }
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_warp) * W, TIERED_BLOCK_THREADS);
+  tiered_bitonic_band_kernel<T, W, IPT, TIERED_BLOCK_THREADS>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      d_input, d_offsets, d_warp_segs, num_warp, band_lo, band_hi, polarity, d_out);
+  CUDF_CHECK_CUDA(stream.value());
+}
+
+/**
+ * @brief Run-time predicate for the tiered fast path on a key column's type
+ *
+ * True for the reps the path instantiates: int32 / int64, plus FLOAT32 / FLOAT64 and every
+ * TIMESTAMP / DURATION (whose int32 / int64 rep flows through the same width-keyed path via
+ * `radix_encode_*`). DECIMAL128, DECIMAL32/64, the narrower integrals, and the non-fixed-width
+ * types are excluded and fall through to the paths below.
+ *
+ * @param type The key column's data type
+ * @return true if the type is eligible for the tiered fast path
+ */
+inline bool is_tiered_sort_supported(data_type type)
+{
+  return type.id() == type_id::INT32 or type.id() == type_id::INT64 or
+         cudf::is_floating_point(type) or cudf::is_chrono(type);
+}
+
+/**
+ * @brief Sorts only the radix-tier segments' elements via the packed-radix key, scattering the
+ * result into the output gather map
+ *
+ * The radix tier -- segments above the warp-tile cap -- is rare (typically the single oversized
+ * segment the list generator forces), so sorting the whole column would waste a full-width global
+ * radix on the many elements the network and warp tiers already handle. This instead keys just the
+ * compacted radix-tier element indices with the same packed key the numeric packed-radix path uses
+ * (segment ordinal, null flag, order-preserving value), radix-sorts that subset, and scatters each
+ * sorted global index to the slot it fills. `d_large_gidx` holds those elements' global indices in
+ * ascending order -- which are exactly the radix-tier output slots in order -- and the radix orders
+ * the subset by (segment, value), so `d_out[d_large_gidx[j]] = sorted_gidx[j]` writes each such
+ * segment's k-th smallest element to its k-th slot. `d_large_gidx` is the radix's value input and
+ * is left unmodified so it doubles as the scatter map. Called only when a radix-tier segment
+ * exists, over `num_large_elems`, not the whole column.
+ */
+template <typename T>
+void radix_sort_large_segments(column_device_view const& d_input,
+                               size_type const* d_segment_ids,
+                               bool has_nulls,
+                               sort_polarity polarity,
+                               int segment_bits,
+                               size_type const* d_large_gidx,
+                               size_type num_large_elems,
+                               size_type* d_out,
+                               rmm::cuda_stream_view stream)
+{
+  auto const alloc = cudf::get_current_device_resource_ref();
+  rmm::device_uvector<size_type> sorted_gidx(num_large_elems, stream);
+
+  // Key each compacted radix-tier index directly (a global index is the builder's input), pair it
+  // with that index, and radix-sort. The value input `d_large_gidx` is read-only, so it survives
+  // for the scatter below. Each branch mirrors the width-specific key and byte-pass count of the
+  // packed-radix path, restricted to the subset.
+  if constexpr (sizeof(T) <= 4) {
+    rmm::device_uvector<cuda::std::uint64_t> keys_in(num_large_elems, stream);
+    rmm::device_uvector<cuda::std::uint64_t> keys_out(num_large_elems, stream);
+    thrust::transform(
+      rmm::exec_policy_nosync(stream, alloc),
+      d_large_gidx,
+      d_large_gidx + num_large_elems,
+      keys_in.begin(),
+      numeric_packed_key_builder<T>{d_segment_ids, d_input, has_nulls, segment_bits, polarity});
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    d_large_gidx,
+                                    sorted_gidx.data(),
+                                    num_large_elems,
+                                    0,
+                                    static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                    stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    d_large_gidx,
+                                    sorted_gidx.data(),
+                                    num_large_elems,
+                                    0,
+                                    static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                    stream.value());
+  } else if constexpr (sizeof(T) == 8) {
+    rmm::device_uvector<prefix_key96> keys_in(num_large_elems, stream);
+    rmm::device_uvector<prefix_key96> keys_out(num_large_elems, stream);
+    thrust::transform(rmm::exec_policy_nosync(stream, alloc),
+                      d_large_gidx,
+                      d_large_gidx + num_large_elems,
+                      keys_in.begin(),
+                      numeric_packed_key_builder64<T>{d_segment_ids, d_input, has_nulls, polarity});
+    auto const decomposer = prefix_decomposer{};
+    // Same trim as the full-column 8-byte branch: seg_null's bits above segment_bits + 1 are
+    // constant zero, so the radix skips their passes (the dec128 key96 discipline).
+    auto const key_bits = cuda::std::min(static_cast<int>(sizeof(prefix_key96) * 8),
+                                         64 + cuda::std::min(32, segment_bits + 1));
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    d_large_gidx,
+                                    sorted_gidx.data(),
+                                    num_large_elems,
+                                    decomposer,
+                                    0,
+                                    key_bits,
+                                    stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    d_large_gidx,
+                                    sorted_gidx.data(),
+                                    num_large_elems,
+                                    decomposer,
+                                    0,
+                                    key_bits,
+                                    stream.value());
+  } else {
+    // The sixteen-byte DECIMAL128 (`__int128`) rep is out of this stage's scope: the run-time
+    // gate `is_tiered_sort_supported` excludes it, so this branch is an unreached fail-safe
+    // until the DECIMAL128 engine lands.
+    CUDF_FAIL("Column type cannot be used with the tiered segmented sort");
+  }
+
+  // The j-th compacted (ascending) radix-tier index is the j-th radix-tier output slot;
+  // sorted_gidx[j] is the element that belongs there, so scatter writes d_out[d_large_gidx[j]] =
+  // sorted_gidx[j].
+  thrust::scatter(rmm::exec_policy_nosync(stream, alloc),
+                  sorted_gidx.begin(),
+                  sorted_gidx.end(),
+                  d_large_gidx,
+                  d_out);
+}
+
+/**
+ * @brief Type-dispatched worker for `fast_segmented_sorted_order_tiered`
+ *
+ * Classifies the segments once with a three-way `cub::DevicePartition::If` (network / warp / radix
+ * tier), reads the two selected counts back to the host, then launches the Batcher-network kernel
+ * for the network class and the full-warp `WarpMergeSort` kernel for the warp class. Any radix-tier
+ * outliers are sorted by a packed radix over just their own elements and scattered into place
+ * (`radix_sort_large_segments`), which adds a second host sync only when such a segment exists. The
+ * enabled overload matches the reps `is_tiered_sort_supported` admits.
+ */
+struct tiered_sort_fn {
+  template <typename T>
+  static constexpr bool is_supported()
+  {
+    return cuda::std::is_same_v<T, int32_t> or cuda::std::is_same_v<T, int64_t> or
+           cudf::is_floating_point<T>() or cudf::is_chrono<T>();
+  }
+
+  template <typename T, CUDF_ENABLE_IF(is_supported<T>())>
+  void operator()(column_view const& segment_offsets,
+                  column_device_view const& d_input,
+                  size_type num_elements,
+                  size_type num_segments,
+                  bool has_nulls,
+                  sort_polarity polarity,
+                  size_type* d_out,
+                  rmm::cuda_stream_view stream) const
+  {
+    auto const d_offsets = segment_offsets.begin<size_type>();
+
+    // Three-way classify the segment indices by size: network (<= TIERED_NETWORK_CAP), warp (<=
+    // TIERED_WARP_CAP), unselected (radix-tier outliers). `large_segs` is the partition's required
+    // third sink; the radix tier is driven off element size (below), not this list, so it is
+    // written but never read.
+    rmm::device_uvector<size_type> network_segs(num_segments, stream);
+    rmm::device_uvector<size_type> warp_segs(num_segments, stream);
+    rmm::device_uvector<size_type> large_segs(num_segments, stream);
+    rmm::device_uvector<size_type> d_counts(2, stream);
+    auto const seg_iter       = cuda::counting_iterator<size_type>{0};
+    auto const select_network = segment_in_network_tier{d_offsets, TIERED_NETWORK_CAP};
+    auto const select_warp = segment_in_warp_tier{d_offsets, TIERED_NETWORK_CAP, TIERED_WARP_CAP};
+    {
+      rmm::device_buffer d_temp_storage;
+      size_t temp_storage_bytes = 0;
+      cub::DevicePartition::If(d_temp_storage.data(),
+                               temp_storage_bytes,
+                               seg_iter,
+                               network_segs.data(),
+                               warp_segs.data(),
+                               large_segs.data(),
+                               d_counts.data(),
+                               num_segments,
+                               select_network,
+                               select_warp,
+                               stream.value());
+      d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+      cub::DevicePartition::If(d_temp_storage.data(),
+                               temp_storage_bytes,
+                               seg_iter,
+                               network_segs.data(),
+                               warp_segs.data(),
+                               large_segs.data(),
+                               d_counts.data(),
+                               num_segments,
+                               select_network,
+                               select_warp,
+                               stream.value());
+    }
+    auto const h_counts =
+      cudf::detail::make_host_vector(device_span<size_type const>{d_counts.data(), 2}, stream);
+    auto const num_network = h_counts[0];
+    auto const num_warp    = h_counts[1];
+    auto const num_large   = num_segments - num_network - num_warp;
+
+    // Radix-tier outliers: sort only their elements with the packed-radix key and scatter them into
+    // their (disjoint) output slots; the network and warp tiers fill the rest, so every slot is
+    // written exactly once. When no segment is in the radix tier the whole block is skipped -- no
+    // labeling, compaction, radix, or extra host sync -- so the tiny-segment common case pays
+    // nothing for a tier it does not use.
+    if (num_large > 0) {
+      rmm::device_uvector<size_type> segment_ids(num_elements, stream);
+      label_segments(segment_offsets.begin<size_type>(),
+                     segment_offsets.end<size_type>(),
+                     segment_ids.begin(),
+                     segment_ids.end(),
+                     stream);
+      auto const segment_bits =
+        static_cast<int>(cuda::std::bit_width(static_cast<cuda::std::uint64_t>(num_segments)));
+
+      // Compact the global indices of the radix-tier segments' elements (ascending, hence grouped
+      // by segment then position), then read their count back -- the one extra sync the radix tier
+      // adds.
+      rmm::device_uvector<size_type> large_gidx(num_elements, stream);
+      rmm::device_uvector<size_type> d_num_large_elems(1, stream);
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        auto const is_large = element_in_radix_tier{segment_ids.data(), d_offsets, TIERED_WARP_CAP};
+        cub::DeviceSelect::If(d_temp_storage.data(),
+                              temp_storage_bytes,
+                              seg_iter,
+                              large_gidx.data(),
+                              d_num_large_elems.data(),
+                              num_elements,
+                              is_large,
+                              stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceSelect::If(d_temp_storage.data(),
+                              temp_storage_bytes,
+                              seg_iter,
+                              large_gidx.data(),
+                              d_num_large_elems.data(),
+                              num_elements,
+                              is_large,
+                              stream.value());
+      }
+      auto const h_num_large_elems = cudf::detail::make_host_vector(
+        device_span<size_type const>{d_num_large_elems.data(), 1}, stream);
+      radix_sort_large_segments<T>(d_input,
+                                   segment_ids.data(),
+                                   has_nulls,
+                                   polarity,
+                                   segment_bits,
+                                   large_gidx.data(),
+                                   h_num_large_elems[0],
+                                   d_out,
+                                   stream);
+    }
+
+    auto const pad_key = tiered_pad_key<T>();
+    if (num_network > 0) {
+      auto const grid =
+        cudf::detail::grid_1d(static_cast<thread_index_type>(num_network), TIERED_BLOCK_THREADS);
+      tiered_network_sort_kernel<T, TIERED_BLOCK_THREADS>
+        <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(d_input,
+                                                                             d_offsets,
+                                                                             network_segs.data(),
+                                                                             num_network,
+                                                                             has_nulls,
+                                                                             polarity,
+                                                                             d_out,
+                                                                             tiered_key_less{},
+                                                                             pad_key);
+      CUDF_CHECK_CUDA(stream.value());
+    }
+    // Warp tier: segment-size sub-bands routed to the kernel measured best for this (type,
+    // null-presence). Each band launches over the full warp-segment list and self-filters to its
+    // size slice, so the sub-bands need no re-partition. No-null INT32 uses a register bitonic
+    // across the whole band; no-null INT64 a bitonic to 32 then a raw-key WarpMergeSort for 33-64
+    // (the raw 8-byte value halves the key traffic vs the packed key at that width); a null-bearing
+    // INT32 / INT64 a full-warp packed-key WarpMergeSort at one item per lane to 32 then two to 64.
+    // Every other tiered type (float, chrono, DECIMAL128) keeps the shipped whole-band packed
+    // WarpMergeSort
+    // -- the raw-key / bitonic kernels are unmeasured there, so those types stay on the proven
+    // path.
+    if (num_warp > 0) {
+      auto const* wl = warp_segs.data();
+      if constexpr (cuda::std::is_same_v<T, int32_t> or cuda::std::is_same_v<T, int64_t>) {
+        if (has_nulls) {
+          launch_packed_warp_band<T, TIERED_WARP_LANES, 1>(d_input,
+                                                           d_offsets,
+                                                           wl,
+                                                           num_warp,
+                                                           has_nulls,
+                                                           polarity,
+                                                           TIERED_NETWORK_CAP,
+                                                           32,
+                                                           d_out,
+                                                           stream);
+          launch_packed_warp_band<T, TIERED_WARP_LANES, TIERED_WARP_ITEMS>(d_input,
+                                                                           d_offsets,
+                                                                           wl,
+                                                                           num_warp,
+                                                                           has_nulls,
+                                                                           polarity,
+                                                                           32,
+                                                                           TIERED_WARP_CAP,
+                                                                           d_out,
+                                                                           stream);
+        } else {
+          launch_bitonic_band<T, 4, 4>(
+            d_input, d_offsets, wl, num_warp, polarity, TIERED_NETWORK_CAP, 16, d_out, stream);
+          launch_bitonic_band<T, 8, 4>(
+            d_input, d_offsets, wl, num_warp, polarity, 16, 32, d_out, stream);
+          if constexpr (cuda::std::is_same_v<T, int32_t>) {
+            launch_bitonic_band<T, 16, 4>(
+              d_input, d_offsets, wl, num_warp, polarity, 32, TIERED_WARP_CAP, d_out, stream);
+          } else {
+            launch_raw_warp_band<T, TIERED_WARP_LANES, TIERED_WARP_ITEMS>(
+              d_input, d_offsets, wl, num_warp, polarity, 32, TIERED_WARP_CAP, d_out, stream);
+          }
+        }
+      } else {
+        auto const grid = cudf::detail::grid_1d(
+          static_cast<thread_index_type>(num_warp) * TIERED_WARP_LANES, TIERED_BLOCK_THREADS);
+        tiered_warp_sort_kernel<T, TIERED_WARP_LANES, TIERED_WARP_ITEMS, TIERED_BLOCK_THREADS>
+          <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(d_input,
+                                                                               d_offsets,
+                                                                               wl,
+                                                                               num_warp,
+                                                                               has_nulls,
+                                                                               polarity,
+                                                                               d_out,
+                                                                               tiered_key_less{},
+                                                                               pad_key);
+        CUDF_CHECK_CUDA(stream.value());
+      }
+    }
+  }
+
+  template <typename T, CUDF_ENABLE_IF(not is_supported<T>())>
+  void operator()(column_view const&,
+                  column_device_view const&,
+                  size_type,
+                  size_type,
+                  bool,
+                  sort_polarity,
+                  size_type*,
+                  rmm::cuda_stream_view) const
+  {
+    CUDF_FAIL("Column type cannot be used with the tiered segmented sort");
+  }
+};
+
 }  // namespace
 
 [[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_numeric_packed(
@@ -395,6 +1446,37 @@ inline bool is_numeric_packed_radix_supported(data_type type)
   return sorted_indices;
 }
 
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_tiered(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+  auto const d_input      = column_device_view::create(input, stream);
+  auto const has_nulls    = input.has_nulls();
+
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+
+  // Dispatch on the storage type so DECIMAL128 sorts by its __int128 rep and DECIMAL32/64,
+  // timestamps, and durations by their integer rep; the functor picks the uint64, unsigned
+  // __int128, or tiered_key128 key by width and writes the sorted indices into d_out.
+  cudf::type_dispatcher<dispatch_storage_type>(input.type(),
+                                               tiered_sort_fn{},
+                                               segment_offsets,
+                                               *d_input,
+                                               num_elements,
+                                               num_segments,
+                                               has_nulls,
+                                               polarity,
+                                               sorted_indices->mutable_view().begin<size_type>(),
+                                               stream);
+  return sorted_indices;
+}
+
 fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
                                                    size_type num_rows,
                                                    column_view const& segment_offsets,
@@ -408,15 +1490,30 @@ fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
   auto const num_offsets   = segment_offsets.size();
   auto const avg_list_size = num_rows / num_offsets;
 
-  // Validity folds into the packed key, so a null-bearing column skips the separate null partition
-  // at any list size.
-  if (key.has_nulls()) { return fixed_width_sort_path::packed_radix; }
+  // Types the tiered key can't encode: keep main's packed-radix-or-CUB decision.
+  if (not is_tiered_sort_supported(type)) {
+    return (key.has_nulls() or not prefer_cub_segmented_sort(num_rows, num_offsets))
+             ? fixed_width_sort_path::packed_radix
+             : fixed_width_sort_path::comparison;
+  }
+  // Tiered sort folds validity into the key, so nulls need no separate pass, at any list size.
+  if (key.has_nulls()) { return fixed_width_sort_path::tiered; }
   // Long lists amortize the global packed-key radix's bandwidth-bound pass.
   if (avg_list_size >= MAX_AVG_LIST_SIZE_FOR_FAST_SORT) {
     return fixed_width_sort_path::packed_radix;
   }
-  // The short no-null remainder keeps the CUB-or-comparison decision of the gate below.
-  return fixed_width_sort_path::comparison;
+  // Floating point no-null short: tiered across the range.
+  if (cudf::is_floating_point(type)) { return fixed_width_sort_path::tiered; }
+  // Eight-byte no-null: tiered across the range. The tiered warp kernels (register bitonic to 32,
+  // raw-key `WarpMergeSort` for 33-64) beat CUB `DeviceSegmentedSort` for INT64 mid-band lists, so
+  // INT64 no longer prefers CUB there. Chrono (and any non-integral 8-byte rep) must stay on tiered
+  // regardless: `column_fast_sort_fn` (the CUB engine) sorts only integral reps --
+  // `dispatch_storage_type` does not reduce a timestamp/duration to its integer rep -- so routing
+  // them to `cub_segmented` would hit that engine's disabled overload (`CUDF_FAIL`), a regression
+  // from main's comparison path.
+  if (cudf::size_of(type) == 8) { return fixed_width_sort_path::tiered; }
+  // Four-byte int/chrono no-null short: tiered.
+  return fixed_width_sort_path::tiered;
 }
 
 }  // namespace detail

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -283,9 +283,13 @@ std::unique_ptr<column> segmented_sorted_order_common(
   }
 
   // fast-path for a single fixed-width key column sorted ascending with nulls last (unstable only).
-  // `choose_fixed_width_sort_path` routes a no-null column with long enough lists to one global
-  // packed-radix sort that reproduces the comparison sort's ascending / nulls-last order without a
-  // cardinality-scaled cost; every other shape takes the comparison path. The order and null
+  // For a tiered-eligible type, `choose_fixed_width_sort_path` routes a null-bearing column, or a
+  // no-null column with short lists, to an in-register / in-warp tiered sort, and a no-null column
+  // with long enough lists to one global packed-radix sort; a packed-radix-eligible type outside
+  // the tiered set takes the packed-radix sort when null-bearing or when the CUB segmented sort is
+  // not preferred for its shape. Both engines reproduce the comparison sort's ascending /
+  // nulls-last order without a cardinality-scaled cost, and any shape the gate declines falls
+  // through to the pre-existing CUB-fast-sort-or-comparison decision below. The order and null
   // precedence must be stated explicitly, so any other configuration -- including the
   // defaulted-argument cases -- falls through unchanged.
   if constexpr (method == sort_method::UNSTABLE) {
@@ -297,6 +301,10 @@ std::unique_ptr<column> segmented_sorted_order_common(
         fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
       auto const path =
         choose_fixed_width_sort_path(keys.column(0), keys.num_rows(), segment_offsets, stream);
+      if (path == fixed_width_sort_path::tiered) {
+        return fast_segmented_sorted_order_tiered(
+          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+      }
       if (path == fixed_width_sort_path::packed_radix) {
         return fast_segmented_sorted_order_numeric_packed(
           keys.column(0), segment_offsets, sort_polarity{}, stream, mr);

--- a/cpp/src/sort/segmented_sort_keys.cuh
+++ b/cpp/src/sort/segmented_sort_keys.cuh
@@ -13,6 +13,18 @@
 namespace cudf {
 namespace detail {
 
+// Class of an element within the tiered ordering key. The ranks are load-bearing: classes 0 and 1
+// go to valid-then-null under the nulls-last polarity and null-then-valid under nulls-first (via
+// `sort_polarity::element_class`), and both sort before the pad the network / `WarpMergeSort`
+// assigns to the slots past a segment's real elements. `tier_pad` MUST rank strictly above both
+// element classes: `cub::BlockMergeSortStrategy::Sort` fills those slots with the pad key and
+// requires it ordered after every valid item, so a flag value tying an element class with the pad
+// could let the merge displace a real element past the valid-item boundary and drop it.
+enum tiered_element_class : cuda::std::uint32_t { tier_valid = 0, tier_null = 1, tier_pad = 2 };
+
+/// Block size hosting the register/warp tiered virtual warps and the graduated-string warp bands.
+constexpr int TIERED_BLOCK_THREADS = 128;
+
 /**
  * @brief Runtime key polarity realizing one explicit (order, null_order) on the segmented-sort
  * fast paths

--- a/cpp/src/sort/segmented_sort_warp_kernel.cuh
+++ b/cpp/src/sort/segmented_sort_warp_kernel.cuh
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <cudf/detail/utilities/assert.cuh>
+#include <cudf/detail/utilities/grid_1d.cuh>
+#include <cudf/types.hpp>
+
+#include <cub/warp/warp_merge_sort.cuh>
+
+namespace cudf {
+namespace detail {
+
+/**
+ * @brief Warp-tier `cub::WarpMergeSort` kernel over a segment-size band, key type and builder
+ * generic
+ *
+ * The key type, builder, comparator and pad are template / value parameters, so the packed
+ * (null-aware) and raw (no-null) modes and every `(W, IPT)` shape share one body. A virtual warp of
+ * `W` lanes owns one segment from `d_seg_list`; a warp whose segment size falls outside
+ * `(band_lo, band_hi]` returns before sorting. All `W` lanes share `seg_size`, so a whole virtual
+ * warp returns together and never desynchronizes the `__syncwarp` inside `WarpMergeSort` -- which
+ * lets several bands share one segment list without re-partitioning it. Slots past the segment's
+ * real size hold the pad key; writing back only `[0, seg_size)` yields the sorted order (valid
+ * ascending, then nulls under the packed key). A function template so the STABLE translation unit,
+ * which never instantiates the tiered path, emits no unused `static` kernel under -Werror.
+ */
+template <typename KeyT, typename KeyBuilder, int W, int IPT, int BLOCK_THREADS, typename CompareOp>
+CUDF_KERNEL __launch_bounds__(BLOCK_THREADS) void tiered_warp_band_kernel(
+  size_type const* d_offsets,
+  size_type const* d_seg_list,
+  size_type num_class_segments,
+  size_type band_lo,
+  size_type band_hi,
+  KeyBuilder build_key,
+  size_type* d_out,
+  CompareOp compare_op,
+  KeyT pad_key)
+{
+  using WarpMergeSortT           = cub::WarpMergeSort<KeyT, IPT, W, size_type>;
+  constexpr int VWARPS_PER_BLOCK = BLOCK_THREADS / W;
+  __shared__ typename WarpMergeSortT::TempStorage temp_storage[VWARPS_PER_BLOCK];
+
+  auto const global_tid = cudf::detail::grid_1d::global_thread_id<BLOCK_THREADS>();
+  auto const vwarp_id   = static_cast<size_type>(global_tid / W);
+  auto const lane       = static_cast<int>(threadIdx.x % W);
+  auto const vwarp_slot = static_cast<int>(threadIdx.x / W);
+  if (vwarp_id >= num_class_segments) { return; }
+
+  auto const seg       = d_seg_list[vwarp_id];
+  auto const seg_start = d_offsets[seg];
+  auto const seg_size  = d_offsets[seg + 1] - seg_start;
+  if (seg_size <= band_lo || seg_size > band_hi) { return; }
+  // The register tile holds W*IPT elements; a band_hi above that would silently drop elements.
+  cudf_assert(seg_size <= W * IPT && "band segment exceeds the register tile (band_hi > W*IPT)");
+
+  KeyT keys[IPT];
+  size_type vals[IPT];
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) {
+      auto const gidx = seg_start + local;
+      keys[i]         = build_key(gidx);
+      vals[i]         = gidx;
+    } else {
+      keys[i] = pad_key;
+      vals[i] = size_type{0};
+    }
+  }
+
+  WarpMergeSortT(temp_storage[vwarp_slot])
+    .StableSort(keys, vals, compare_op, static_cast<int>(seg_size), pad_key);
+
+#pragma unroll
+  for (int i = 0; i < IPT; ++i) {
+    auto const local = lane * IPT + i;
+    if (local < seg_size) { d_out[seg_start + local] = vals[i]; }
+  }
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -330,6 +330,304 @@ TEST_F(SortListsInt, NumericPackedBoolWithNulls)
   expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
 }
 
+// The tiered kernel's class-composition seam: one int32 column whose row sizes straddle both
+// internal tier boundaries -- network (<=8): 0, 1, 3, 8; warp (9..64): 9, 33, 64; radix (>64): 65,
+// 600, 3000 -- so the Batcher-network kernel, the full-warp kernel, and the compact large-segment
+// radix fallback all run and must merge into one gather map with no cross-row contamination. The
+// sizes include both exact caps (8 and 64) and their first over-cap neighbours (9 and 65).
+// Scattered element nulls make the column null-bearing, which is what routes it to the tiered
+// kernel regardless of its average size; each row is reverse-sorted with a duplicate, and the
+// expected column is an independent host sort per row (ascending, nulls last). This is the
+// likeliest bug site for a tiered design.
+TEST_F(SortListsInt, NumericTieredThreeSizeClasses)
+{
+  std::vector<cudf::size_type> const sizes{0, 1, 3, 8, 9, 33, 64, 65, 600, 3'000};
+  std::vector<int32_t> in_vals;
+  std::vector<bool> in_valids;
+  std::vector<int32_t> ex_vals;
+  std::vector<bool> ex_valids;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int32_t> rv(s);
+    std::vector<bool> rok(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i]  = static_cast<int32_t>(s - i);  // distinct, descending -> the sort must fully reorder
+      rok[i] = (i % 7 != 3);                 // scattered element nulls
+    }
+    if (s >= 2) { rv[1] = rv[0]; }  // a duplicate value among the non-nulls
+    std::vector<int32_t> nn;
+    for (cudf::size_type i = 0; i < s; ++i) {
+      in_vals.push_back(rv[i]);
+      in_valids.push_back(rok[i]);
+      if (rok[i]) { nn.push_back(rv[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    for (auto const v : nn) {
+      ex_vals.push_back(v);
+      ex_valids.push_back(true);
+    }
+    for (cudf::size_type k = static_cast<cudf::size_type>(nn.size()); k < s; ++k) {
+      ex_vals.push_back(0);
+      ex_valids.push_back(false);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int32_t> const& vals, std::vector<bool> const& valids) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(vals.begin(), vals.end(), valids.begin());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals, in_valids);
+  auto const expected = make_list(ex_vals, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Every other tiered-kernel test keeps each tier's segment count small enough that `grid_1d` needs
+// only one block (TIERED_BLOCK_THREADS is 128, and the warp tier packs 128/32 = 4 virtual warps per
+// block). This drives 200 network-tier and 10 warp-tier segments into one no-null int32 column
+// (which routes to the tiered kernel), so both kernels' grids span >= 2 blocks, exercising
+// `global_thread_id<BLOCK_THREADS>()` across a block boundary.
+TEST_F(SortListsInt, NumericTieredMultiBlockGrid)
+{
+  std::vector<cudf::size_type> sizes;
+  for (int i = 0; i < 200; ++i) {
+    sizes.push_back(1 + (i % 8));
+  }  // 200 network-tier segments
+  for (int i = 0; i < 10; ++i) {
+    sizes.push_back(16 + (i % 40));
+  }  // 10 warp-tier segments
+  std::vector<int32_t> in_vals;
+  std::vector<int32_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int32_t> rv(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = static_cast<int32_t>(s - i);
+    }
+    for (auto const v : rv) {
+      in_vals.push_back(v);
+    }
+    std::sort(rv.begin(), rv.end());
+    for (auto const v : rv) {
+      ex_vals.push_back(v);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int32_t> const& vals) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(vals.begin(), vals.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Zero-one principle, in-repo: the eight-slot Batcher network sorts every 0/1 pattern at every list
+// size 1 through 8 (510 lists, 3586 elements; a no-null int32 column of this shape routes to the
+// tiered kernel with every segment in the network tier). A comparison network that sorts every 0/1
+// input sorts every totally ordered input, so this permanently pins the hand-unrolled
+// 19-comparator sequence against future edits.
+TEST_F(SortListsInt, NumericTieredNetworkZeroOneExhaustive)
+{
+  std::vector<int32_t> vals;
+  std::vector<int32_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (int n = 1; n <= 8; ++n) {
+    for (int pattern = 0; pattern < (1 << n); ++pattern) {
+      int ones = 0;
+      for (int b = 0; b < n; ++b) {
+        int const bit = (pattern >> b) & 1;
+        vals.push_back(bit);
+        ones += bit;
+      }
+      for (int b = 0; b < n; ++b) {
+        ex_vals.push_back(b < n - ones ? 0 : 1);
+      }
+      offsets.push_back(static_cast<cudf::size_type>(vals.size()));
+    }
+  }
+  auto const num_lists = static_cast<cudf::size_type>(offsets.size() - 1);
+  auto const make_list = [&](std::vector<int32_t> const& v) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(v.begin(), v.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_lists, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Nonzero column offset (from cudf::slice) combined with a retained null element: slicing off row 0
+// gives the surviving rows' child column a genuine nonzero column_view::offset() (via
+// lists_column_view::get_sliced_child), and row 1's null must still be read correctly through
+// column_device_view::is_null() at that offset by the tiered engine (a null-bearing int column
+// routes there). SortListsInt.Sliced covers the offset alone (no nulls); this adds the offset +
+// null combo.
+TEST_F(SortListsInt, SlicedWithNulls)
+{
+  using T = int;
+  std::vector<bool> const valids{true, false, true};  // row 1's middle element (5) is null
+  LCW<T> l{{3, 2, 1, 4}, {{7, 5, 6}, valids.begin()}, {8, 9}, {10}};
+
+  auto const sliced_list = cudf::slice(l, {1, 4})[0];  // drops row 0 -> nonzero child offset
+  std::vector<bool> const ex_valids{true, true, false};
+  auto const expected = LCW<T>{{{6, 7, 0}, ex_valids.begin()}, {8, 9}, {10}};
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{sliced_list}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// The tiered kernel's warp tier in isolation: three single-row columns within the warp cap (64) and
+// no larger segment, so the radix fallback never runs and the full-warp kernels alone must be
+// correct. Scattered element nulls route each column to the tiered kernel. An int64
+// sixty-four-element row fills the 32*2 warp tile exactly (no pads); a DECIMAL128 fifty-element row
+// leaves pad slots; a double sixty-four-element row fills the generic tiered_warp_sort_kernel's
+// tile exactly (zero pads on the shared non-int32/int64 path). Each is reverse-sorted with a
+// duplicate; the expected column is an independent host sort (ascending, nulls last).
+TEST_F(SortListsInt, NumericTieredWarpSegments)
+{
+  auto constexpr scale = numeric::scale_type{0};
+  {  // int64 warp tier.
+    cudf::size_type const n = 64;
+    std::vector<int64_t> in(n);
+    std::vector<bool> in_v(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] =
+        static_cast<int64_t>(n - i) * 1'000'000'007LL;  // distinct, descending, beyond 32 bits
+      in_v[i] = (i % 5 != 2);                           // scattered nulls
+    }
+    in[1] = in[0];  // a duplicate value among the non-nulls
+    std::vector<int64_t> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (in_v[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<int64_t> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, int64_t{0});
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(in.begin(), in.end(), in_v.begin())
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(ex.begin(), ex.end(), ex_v.begin())
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // decimal128 warp tier (24-byte key).
+    cudf::size_type const n = 50;
+    std::vector<__int128_t> in(n);
+    std::vector<bool> in_v(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i]   = static_cast<__int128_t>(n - i) * (i % 2 == 0 ? 1 : -1);  // mixed sign, distinct
+      in_v[i] = (i % 6 != 4);
+    }
+    in[3] = in[2];  // a duplicate value
+    std::vector<__int128_t> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (in_v[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<__int128_t> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, __int128_t{0});
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(in.begin(), in.end(), in_v.begin(), scale)
+        .release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_point_column_wrapper<__int128_t>(ex.begin(), ex.end(), ex_v.begin(), scale)
+        .release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // double warp tier at exactly TIERED_WARP_CAP: zero pad slots, full-tile occupancy of the
+     // generic tiered_warp_sort_kernel (the path float/double/chrono/decimal128 share).
+    cudf::size_type const n = 64;
+    std::vector<double> in(n);
+    std::vector<bool> in_v(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i]   = static_cast<double>(n - i);  // distinct, descending
+      in_v[i] = (i % 5 != 2);                // scattered nulls
+    }
+    in[1] = in[0];  // a duplicate value among the non-nulls
+    std::vector<double> nn;
+    for (cudf::size_type i = 0; i < n; ++i) {
+      if (in_v[i]) { nn.push_back(in[i]); }
+    }
+    std::sort(nn.begin(), nn.end());
+    std::vector<double> ex = nn;
+    std::vector<bool> ex_v(nn.size(), true);
+    ex.resize(n, 0.0);
+    ex_v.resize(n, false);
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<double>(in.begin(), in.end(), in_v.begin()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<double>(ex.begin(), ex.end(), ex_v.begin()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
+// int64 no-null mid band on the tiered kernel's network and warp tiers for the eight-byte rep. A
+// single row of eight elements lands in the network tier (Batcher-8); one of sixteen in the warp
+// tier, where a no-null int64 sorts via the register bitonic (raw key). Values exceed INT32_MAX and
+// span the sign boundary; both paths must reproduce the comparison sort's ascending order. The
+// no-null int64 mid band no longer prefers CUB `DeviceSegmentedSort` -- the tiered warp kernels
+// beat it, so `choose_fixed_width_sort_path` routes the whole no-null int64 range below the
+// packed-radix cutoff to the tiered path.
+TEST_F(SortListsInt, NumericMidBandInt64Tiered)
+{
+  auto constexpr big          = int64_t{5} * 1'000 * 1'000 * 1'000;  // > INT32_MAX
+  auto const check_single_row = [big](cudf::size_type n) {
+    std::vector<int64_t> in(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      in[i] = (static_cast<int64_t>(n / 2) - i) * big;
+    }
+    std::vector<int64_t> ex(in);
+    std::sort(ex.begin(), ex.end());
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<int64_t>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  check_single_row(8);   // one segment of eight -> network tier (Batcher-8)
+  check_single_row(16);  // one segment of sixteen -> warp tier, register bitonic (raw key)
+}
+
+// No-null 8-byte chrono (TIMESTAMP/DURATION) in the mid band. `dispatch_storage_type` does not
+// reduce chrono to its integer rep, so the CUB fast path (`column_fast_sort_fn`) cannot sort it;
+// routing an 8-byte no-null chrono to CUB (as an integer of the same width would go) throws
+// CUDF_FAIL. A single row of sixteen (average eight, past the tiered tiny cutoff) must therefore
+// stay on the tiered kernel, which encodes chrono via `radix_encode_*`. Guards that routing for a
+// timestamp and a duration rep against the comparison oracle.
+TEST_F(SortListsInt, NumericMidBandChronoNoNull)
+{
+  std::vector<int64_t> in(16);
+  for (cudf::size_type i = 0; i < 16; ++i) {
+    in[i] = (8 - i) * int64_t{1'000'000'000};
+  }
+  std::vector<int64_t> ex(in);
+  std::sort(ex.begin(), ex.end());
+  {  // TIMESTAMP_MILLISECONDS (int64 rep)
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::timestamp_ms>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+  {  // DURATION_MICROSECONDS (int64 rep)
+    auto input = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::duration_us>(in.begin(), in.end()).release());
+    auto expected = as_single_row_list(
+      cudf::test::fixed_width_column_wrapper<cudf::duration_us>(ex.begin(), ex.end()).release());
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  }
+}
+
 // The exact average-list-size cells of the packed-radix gate (avg >= 100): a 200-element single row
 // (two offsets -> average exactly 100) is the first packed-radix shape, and a 198-element row
 // (average 99) the last tiered shape. Both must reproduce the comparison order, pinning the gate's
@@ -455,6 +753,151 @@ TEST_F(SortListsInt, NumericPackedRadixNoNullNarrowTypes)
   };
   check_decimal(int32_t{});  // DECIMAL32.
   check_decimal(int64_t{});  // DECIMAL64.
+}
+
+// No-null INT32 warp tier: the register bitonic across its three sub-bands (<=16, <=32, <=64). One
+// column of segments straddling every tier boundary -- network (8), the bitonic bands (9, 16, 17,
+// 32, 33, 48, 64), and a radix outlier (65) -- with INT32_MAX (which radix-encodes to the raw-key
+// pad sentinel, so the bitonic pad tie-break must keep it inside the segment), INT32_MIN, and a
+// duplicate. The 8/9, 32/33 and 64/65 boundaries are all present in one column. Verified against
+// the oracle.
+TEST_F(SortListsInt, NumericTieredBitonicNoNullInt32)
+{
+  std::vector<cudf::size_type> const sizes{8, 9, 16, 17, 32, 33, 48, 64, 65};
+  auto constexpr lo = std::numeric_limits<int32_t>::min();
+  auto constexpr hi = std::numeric_limits<int32_t>::max();
+  std::vector<int32_t> in_vals;
+  std::vector<int32_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int32_t> rv(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = static_cast<int32_t>(s - i);
+    }
+    rv[0] = hi;                     // a real INT32_MAX (radix-encodes to the raw-key pad sentinel)
+    if (s >= 2) { rv[1] = lo; }     // INT32_MIN
+    if (s >= 4) { rv[2] = rv[3]; }  // a duplicate value
+    for (auto const v : rv) {
+      in_vals.push_back(v);
+    }
+    std::sort(rv.begin(), rv.end());
+    for (auto const v : rv) {
+      ex_vals.push_back(v);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int32_t> const& vals) {
+    cudf::test::fixed_width_column_wrapper<int32_t> leaf(vals.begin(), vals.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// No-null INT64 warp tier, pinning the bitonic/narrow split: the register bitonic handles segments
+// up to 32, a raw-key `WarpMergeSort` (narrow) segments 33..64. Sizes 9, 32, 33, 64, 65 pin the
+// 32/33 (bitonic->narrow) and 64/65 (warp->radix) boundaries; 40 and 48 add interior narrow-band
+// shapes where pad slots coexist with the INT64_MAX element. Values exceed INT32_MAX and include
+// INT64_MAX (which encodes to exactly the raw-key pad sentinel, so the merge must keep the real
+// element inside the valid range whatever pads exist), INT64_MIN, and a duplicate. Verified against
+// the comparison oracle.
+TEST_F(SortListsInt, NumericTieredBitonicNarrowNoNullInt64)
+{
+  std::vector<cudf::size_type> const sizes{9, 32, 33, 40, 48, 64, 65};
+  auto constexpr lo  = std::numeric_limits<int64_t>::min();
+  auto constexpr hi  = std::numeric_limits<int64_t>::max();
+  auto constexpr big = int64_t{5} * 1'000 * 1'000 * 1'000;  // > INT32_MAX
+  std::vector<int64_t> in_vals;
+  std::vector<int64_t> ex_vals;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const s : sizes) {
+    std::vector<int64_t> rv(s);
+    for (cudf::size_type i = 0; i < s; ++i) {
+      rv[i] = (static_cast<int64_t>(s) - i) * big;
+    }
+    rv[0] = hi;                     // a real INT64_MAX (encodes to the raw-key pad sentinel)
+    if (s >= 2) { rv[1] = lo; }     // INT64_MIN
+    if (s >= 4) { rv[2] = rv[3]; }  // a duplicate value
+    for (auto const v : rv) {
+      in_vals.push_back(v);
+    }
+    std::sort(rv.begin(), rv.end());
+    for (auto const v : rv) {
+      ex_vals.push_back(v);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+  }
+  auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+  auto const make_list = [&](std::vector<int64_t> const& vals) {
+    cudf::test::fixed_width_column_wrapper<int64_t> leaf(vals.begin(), vals.end());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+  auto const input    = make_list(in_vals);
+  auto const expected = make_list(ex_vals);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Null-bearing INT32 and INT64 warp tier: a null-flagged column routes to the tiered path, whose
+// warp tier uses the full-warp packed-key `WarpMergeSort` at one item per lane up to 32 then two to
+// 64 (the w32x1 shape) for both widths. One column per width with segments 8, 9, 32, 33, 64, 65
+// (spanning the network / warp / radix tiers and the 8/9, 32/33, 64/65 boundaries), scattered nulls
+// placed last, and INT_MIN/MAX plus a duplicate among the non-nulls. Verified against the
+// comparison oracle.
+TEST_F(SortListsInt, NumericTieredW32x1Nulls)
+{
+  std::vector<cudf::size_type> const sizes{8, 9, 32, 33, 64, 65};
+  auto const run = [&](auto tag) {
+    using T           = decltype(tag);
+    auto constexpr lo = std::numeric_limits<T>::min();
+    auto constexpr hi = std::numeric_limits<T>::max();
+    std::vector<T> in_vals;
+    std::vector<bool> in_valids;
+    std::vector<T> ex_vals;
+    std::vector<bool> ex_valids;
+    std::vector<cudf::size_type> offsets{0};
+    for (auto const s : sizes) {
+      std::vector<T> rv(s);
+      std::vector<bool> rok(s);
+      for (cudf::size_type i = 0; i < s; ++i) {
+        rv[i]  = static_cast<T>(s - i);
+        rok[i] = (i % 5 != 2);  // scattered element nulls
+      }
+      rv[0] = hi;
+      if (s >= 2) { rv[1] = lo; }
+      if (s >= 4) { rv[2] = rv[3]; }  // a duplicate among the non-nulls
+      std::vector<T> nn;
+      for (cudf::size_type i = 0; i < s; ++i) {
+        in_vals.push_back(rv[i]);
+        in_valids.push_back(rok[i]);
+        if (rok[i]) { nn.push_back(rv[i]); }
+      }
+      std::sort(nn.begin(), nn.end());
+      for (auto const v : nn) {
+        ex_vals.push_back(v);
+        ex_valids.push_back(true);
+      }
+      for (cudf::size_type k = static_cast<cudf::size_type>(nn.size()); k < s; ++k) {
+        ex_vals.push_back(T{0});
+        ex_valids.push_back(false);
+      }
+      offsets.push_back(static_cast<cudf::size_type>(in_vals.size()));
+    }
+    auto const num_rows  = static_cast<cudf::size_type>(sizes.size());
+    auto const make_list = [&](std::vector<T> const& vals, std::vector<bool> const& valids) {
+      cudf::test::fixed_width_column_wrapper<T> leaf(vals.begin(), vals.end(), valids.begin());
+      cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+      return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+    };
+    auto const input    = make_list(in_vals, in_valids);
+    auto const expected = make_list(ex_vals, ex_valids);
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+  };
+  run(int32_t{});
+  run(int64_t{});
 }
 
 TEST_F(SortListsInt, NestedListElement)


### PR DESCRIPTION
The comparison-based segmented sort pays a per-element comparator cost that dominates when list segments are tiny. Add a tiered engine to the ascending / nulls-after fast path of `cudf::lists::sort_lists`: a segment of up to eight elements sorts in one thread via a fixed register network, a segment of up to 64 on a full warp -- `cub::WarpMergeSort` over a packed key, with register shuffle-bitonic and raw-key bands for no-null `int32` / `int64` -- and a rare larger outlier falls back to a packed radix restricted to just that segment. Validity folds into the key ordering, so null-bearing columns take the tiered kernels directly with no separate null pass.

`choose_fixed_width_sort_path` now routes null-bearing and short no-null columns of the tiered-eligible types (`int32`, `int64`, floating point, chrono) to the tiered engine while long no-null lists stay on the packed radix; DECIMAL128 keeps the comparison path until its dedicated engine lands. Versus the packed-radix foundation underneath, the numbers benchmark certifies 27 impacted cells, all wins, geomean 3.72x and up to 10.26x, with zero regressions; versus main the tiered-routed cells reach geomean 5.17x, up to 15.55x. Tests pin each tier boundary and cross-check the fast path against the stable comparison sort.

---

**Stacked series — part 3/7, decomposing rapidsai/cudf#23101 into reviewable steps.** Stacked on #76 (base branch `improve-list-sort-02-packed-radix`).

**compute-sanitizer:** memcheck + racecheck (`--rmm-mode=cuda`) over `LISTS_TEST` (`SortLists*`, 54 tests) — **0 errors, 0 hazards**.
