### PR TITLE
Add strings prefix-radix fast path for segmented sort (5/7)

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1004,6 +1004,7 @@ add_library(
   src/sort/rank.cu
   src/sort/segmented_sort.cu
   src/sort/segmented_sort_fixed_width.cu
+  src/sort/segmented_sort_strings.cu
   src/sort/segmented_top_k.cu
   src/sort/sort.cu
   src/sort/sort_column.cu

--- a/cpp/benchmarks/sort/sort_list_of_strings.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_strings.cpp
@@ -32,11 +32,11 @@
 // Overwrites the first `min(plen, byte_length)` bytes of every non-null leaf string of a
 // LIST<STRING> column with the constant byte 'A' (0x41), returning a new LIST<STRING> column. The
 // strings keep their original lengths and offsets, so they stay distinct in their tails while now
-// sharing a `plen`-byte leading prefix -- the regime where every compare must scan past the shared
-// prefix before it can distinguish two strings. This is data setup, not a measured operation, so a
-// host round-trip is acceptable and keeps the helper host-compilable (the benchmark is a .cpp).
-// Offset values may be int32 or int64; both are normalized to int64 on the host. The leaf is
-// assumed unsliced (offset 0), which holds for the freshly generated benchmark column.
+// sharing a `plen`-byte leading prefix -- the regime where the packed-prefix key is uninformative
+// and the tie-break does the real work. This is data setup, not a measured operation, so a host
+// round-trip is acceptable and keeps the helper host-compilable (the benchmark is a .cpp). Offset
+// values may be int32 or int64; both are normalized to int64 on the host. The leaf is assumed
+// unsliced (offset 0), which holds for the freshly generated benchmark column.
 static std::unique_ptr<cudf::column> apply_shared_prefix(cudf::column_view const& list_col,
                                                          cudf::size_type plen,
                                                          rmm::cuda_stream_view stream)
@@ -186,13 +186,10 @@ static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view cons
 }
 
 // Benchmark for cudf::lists::sort_lists on a LIST<STRING> column, the operation Spark
-// array_sort(array<string>) lowers to and which a plain table sort does not exercise. STRING is
-// never eligible for the segmented sort's CUB fast path (neither integral nor fixed-point), so
-// every cell measures the generic fallback: a lexicographic comparator sort over a prepended
-// segment-id column, whose string compares scan bytes until they differ. The axes span the shape
-// space that stresses that comparator: list-length regimes, string width, and -- the compare-cost
-// stressor -- how many leading bytes the elements share. The order and null_order axes complete
-// the sort-parameter matrix.
+// array_sort(array<string>) lowers to and which a plain table sort does not exercise. The axes span
+// the shape space a reviewer needs to see the whole picture of the string fast path: list-length
+// regimes, string width, and -- the tie-break stressor -- how many leading bytes the elements
+// share. The order and null_order axes complete the sort-parameter matrix.
 static void bench_sort_list_of_strings(nvbench::state& state)
 {
   auto const num_rows       = static_cast<cudf::size_type>(state.get_int64("num_rows"));
@@ -219,7 +216,7 @@ static void bench_sort_list_of_strings(nvbench::state& state)
   // Build a LIST<STRING> column: list length is uniform in [0, max_list_size] and each string's
   // width is normally distributed in [0, row_width]. Leaf strings are all-distinct (cardinality 0)
   // to match the near-unique elements of the real array_sort workload -- the hardest case for the
-  // comparator, and the one the shared_prefix_len axis stresses further; leaf cardinality is
+  // tie-break, and the one the shared_prefix_len axis stresses further; leaf cardinality is
   // therefore not a separate axis. Nulls are applied at both the list-row and string-element levels
   // so the sort exercises null ordering at the leaf.
   data_profile const profile =
@@ -265,12 +262,9 @@ NVBENCH_BENCH(bench_sort_list_of_strings)
   .add_int64_axis("num_rows", {1'000'000})
   // Tiny / typical / large list lengths: tiny stresses per-segment overhead, large amortizes it.
   .add_int64_axis("max_list_size", {4, 32, 256})
-  // Short strings resolve compares within a few bytes; wide strings give the comparator more bytes
-  // to scan before two strings differ.
+  // Short strings mostly fit the packed key; wide strings push work into the byte-window tie-break.
   .add_int64_axis("row_width", {16, 64})
-  // 0 control (no forced prefix); 8 and 32 make every compare scan at least that many identical
-  // leading bytes. At row_width 16 a 32-byte prefix saturates every string (lengths are clamped to
-  // [0, row_width]), an intentional all-identical-content extreme differing only in length.
+  // 0 control; 8 shares exactly the packed-key width (first tie-break window); 32 spans several.
   .add_int64_axis("shared_prefix_len", {0, 8, 32})
   // No-null vs a realistic null rate to exercise the leaf null ordering.
   .add_float64_axis("null_frequency", {0, 0.1})

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -142,5 +142,75 @@ fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 
+/**
+ * @brief Faster segmented sorted-order for a single STRING key column via iterative radix sort
+ *
+ * Lexicographic string comparison is replaced by radix sorts over a compact key holding the
+ * element's segment and the big-endian-packed leading bytes of its string. The first key is a
+ * single `uint64` laid out `[segment : S bits][class : 1 bit when nullable][prefix : P bits]`
+ * (see `packed_key_layout`), so one global `cub::DeviceRadixSort` over its full 64 bits -- eight
+ * byte-passes, not the twelve the 96-bit iterative key needs -- orders elements by segment, then by
+ * the requested null placement (the `polarity` class bit), then by their leading `P` prefix bits
+ * (complemented under a descending sort). Distinct strings in one segment
+ * sharing those bits remain tied, so instead of a single-threaded comparison tie-break, only the
+ * still-tied elements are compacted out and re-sorted by successive eight-byte windows: each pass
+ * radixes that compacted subset by a 96-bit key whose most-significant field is a dense run rank
+ * (encoding the order resolved so far) and whose low field is the next eight bytes. The run rank
+ * keeps every already-separated element fixed, so a pass only reorders within a tied run, and a
+ * parallel radix replaces the serial per-run sort that made a fully-shared-prefix segment a
+ * multi-second straggler. After each pass the elements that became singletons are frozen at their
+ * final positions and dropped, so the subset shrinks and the loop exits as soon as nothing stays
+ * tied -- a prefix that resolves in one window costs one pass, not the full cap. Whatever stays
+ * tied after the pass cap is finished by one comparison cleanup, so correctness never needs it.
+ *
+ * Correctness equals the lexicographic comparison sort under the requested `polarity` exactly:
+ * - The packed prefix is the top `P` bits of the same big-endian leading-byte value the windows
+ *   pack, so an unsigned compare of the `uint64` reproduces unsigned-byte order over those bits.
+ *   Because `P` is not necessarily a byte multiple, a packed-key match proves only `floor(P/8)`
+ *   *whole* leading bytes equal; the windows and the comparison cleanup therefore both begin at
+ *   `floor(P/8)`, and the iterative run rank is seeded from the packed keys (not a wider prefix) so
+ *   two strings tied on `P` bits are left in one run rather than frozen apart on their lower bits.
+ * - Each window packs bytes big-endian just as the first key does, so an unsigned comparison of the
+ *   packed window reproduces unsigned-byte order over those bytes -- the same ordering the
+ *   comparison path uses.
+ * - A string with no byte left in a window packs to zero (the minimum), so a shorter string that is
+ *   a prefix of a longer one sorts first, reproducing the comparison sort's shorter-is-less length
+ *   tie-break. The residual case where a shorter string and a longer one agree on every byte and
+ *   the longer one's tail is all zero bytes cannot be separated by any window; it is resolved by
+ *   the final comparison cleanup, whose `compare_suffix` returns the length difference.
+ * - The class bit sits just below the segment field -- above every prefix bit -- so a non-null
+ *   string can never set it, and nulls collect on the polarity's requested side within their
+ *   segment with no sentinel prefix needed (closing the all-0xFF-vs-null collision the sentinel
+ *   scheme risked). A null is thus position-final after the first pass; the tie-break never counts
+ *   it tied, so it keeps its first-pass slot, exactly as the comparison path places it.
+ * - `polarity` folds the requested (order, null_order) into these keys: `element_class` sets the
+ *   class bit so nulls land on the requested side, and a descending sort XOR-complements only the
+ *   byte fields (the packed prefix and every window), reversing byte order while leaving the
+ *   segment and null placement untouched. The complement sends an exhausted window's zero to the
+ *   maximum, so the shorter-is-less rule and the cleanup's length tie-break both invert to
+ *   shorter-is-greater -- the length-uniform exhausted-run drop stays valid under either order (it
+ *   reads real lengths and equal-key runs, both complement-invariant). ASCENDING / nulls-after
+ *   keeps every key bit-identical to the shipped configuration (`element_class` and the complement
+ *   are both no-ops there).
+ *
+ * Unlike a rank-encoding approach, no sort of the distinct strings is performed, so the per-pass
+ * cost does not grow with key cardinality. All four explicit (order, null_order) combinations
+ * engage this path; a zero-null column is relaxed to nulls-last so its keys match the shipped
+ * ascending configuration exactly.
+ *
+ * @param input The STRING column whose elements are sorted within each segment
+ * @param segment_offsets Identifies the segments to sort within
+ * @param polarity The requested sort direction and null placement, folded into the radix keys
+ * @param stream CUDA stream used for device memory operations and kernel launches
+ * @param mr Device memory resource used to allocate the returned column's device memory
+ * @return Indices that map the column to a segmented sorted order
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_prefix(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -336,6 +336,25 @@ std::unique_ptr<column> segmented_sorted_order_common(
       keys.column(0), segment_offsets, col_order, stream, mr);
   }
 
+  // fast-path for a single STRING key column sorted ascending with nulls last (unstable only).
+  // A radix sort over a packed key of each element's leading bytes orders them, and the rare prefix
+  // ties are resolved by successive byte windows and a final byte comparison of the remainder,
+  // replacing the lexicographic comparison sort without any cost that scales with key cardinality.
+  // The order and null precedence must be stated explicitly so any other configuration -- including
+  // the defaulted-argument cases -- falls through to the comparison path below with its order
+  // unchanged.
+  if constexpr (method == sort_method::UNSTABLE) {
+    // As at the fixed-width gate: the cheap scalar checks precede the synchronizing coverage probe.
+    if (keys.num_columns() == 1 and keys.column(0).type().id() == type_id::STRING and
+        (segment_offsets.size() > 0) and column_order.size() == 1 and
+        column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
+        null_precedence.front() == null_order::AFTER and
+        fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+      return fast_segmented_sorted_order_strings_prefix(
+        keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+    }
+  }
+
   // Get segment id of each element in all segments.
   auto segment_ids = get_segment_indices(keys.num_rows(), segment_offsets, stream);
 

--- a/cpp/src/sort/segmented_sort_strings.cu
+++ b/cpp/src/sort/segmented_sort_strings.cu
@@ -1,0 +1,1081 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "segmented_sort_fast.cuh"
+#include "segmented_sort_keys.cuh"
+
+#include <cudf/column/column_device_view.cuh>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/device_scalar.hpp>
+#include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/strings/string_view.cuh>
+#include <cudf/utilities/error.hpp>
+#include <cudf/utilities/memory_resource.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/device_uvector.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cub/device/device_radix_sort.cuh>
+#include <cub/device/device_scan.cuh>
+#include <cub/device/device_select.cuh>
+#include <cuda/iterator>
+#include <cuda/std/algorithm>
+#include <cuda/std/bit>
+#include <cuda/std/cstdint>
+#include <cuda/std/functional>
+#include <cuda/std/limits>
+#include <cuda/std/utility>
+#include <thrust/count.h>
+#include <thrust/for_each.h>
+#include <thrust/reduce.h>
+#include <thrust/scatter.h>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
+
+namespace cudf {
+namespace detail {
+namespace {
+
+/**
+ * @brief Number of leading string bytes packed per big-endian window (the `uint64` byte capacity)
+ *
+ * Each iterative window packs this many bytes, and `packed_key_builder` reads at most this many
+ * leading bytes before keeping the prefix bits that fit. Declared as a plain `constexpr` (its value
+ * is read in host code) -- the value remains usable from device code.
+ */
+constexpr size_type prefix_bytes = sizeof(cuda::std::uint64_t);
+
+/**
+ * @brief Bit layout of the single-`uint64` first-pass radix key
+ *
+ * The initial sort uses one `uint64`, not the wider iterative `prefix_key96`, so the radix touches
+ * `end_bit/8 = 8` byte-passes, not twelve. The word is laid out most- to least-significant as
+ * `[segment_id : S bits][is_null : 1 bit, only when the column has nulls][prefix : P bits]`, an
+ * unsigned compare of which reproduces the `prefix_key96` ordering: segment first, then non-nulls
+ * (is_null 0) before nulls (is_null 1), then the packed leading bytes. `S` is the bit width of the
+ * largest possible segment label; `P` is whatever is left, holding the top `P` bits of the same
+ * big-endian leading-byte value the windows pack. Placing `is_null` just below `segment_id` -- a
+ * bit a non-null string's prefix can never reach -- means a non-null whose leading bytes are all
+ * 0xFF can no longer collide with a null, so no null sentinel is needed in this key.
+ *
+ * `P` encodes only `floor(P/8)` *whole* known-equal bytes once the key matches; the partial
+ * trailing bits prove nothing about the next byte. So strings sharing the packed key are ordered
+ * afterward by the iterative byte windows and the comparison cleanup, both started at `floor(P/8)`
+ * rather than a fixed eight -- the only offset that holds when `P` is not a byte multiple.
+ */
+struct packed_key_layout {
+  int segment_bits;  // S: bit_width of the maximum segment label (host-computed once).
+  int null_bits;     // 1 when the column has nulls (the is_null bit is present), else 0.
+  int prefix_bits;   // P = 64 - S - null_bits: the leading-byte bits the key can still hold.
+};
+
+/**
+ * @brief Computes the `uint64` key layout for `num_segment_labels` distinct segment-label values
+ *
+ * `num_segment_labels` is the largest segment-label value the key must distinguish plus one. The
+ * caller labels each element with its dense segment ordinal (`0, 1, ...` over the segments), whose
+ * maximum is `num_segments - 1`, so the bound passed here is `num_segments` rather than the row
+ * count -- the ordinals are dense in the segment count, not offset-derived. `S = bit_width` of
+ * `num_segment_labels` reserves enough high bits, and `P` takes the remainder after the optional
+ * null bit; the tighter `S` (segments, not rows) widens `P`, packing more leading bytes per key.
+ */
+inline packed_key_layout make_packed_key_layout(size_type num_segment_labels, bool has_nulls)
+{
+  auto const max_label    = static_cast<cuda::std::uint64_t>(num_segment_labels);
+  auto const segment_bits = cuda::std::bit_width(max_label);
+  auto const null_bits    = has_nulls ? 1 : 0;
+  return packed_key_layout{segment_bits, null_bits, 64 - segment_bits - null_bits};
+}
+
+/**
+ * @brief Builds the per-element single-`uint64` first-pass key (see `packed_key_layout`)
+ *
+ * Packs the segment label into the top `S` bits, the polarity's class bit (when the column is
+ * nullable) into the bit just below, and the top `P` bits of the element's big-endian leading-byte
+ * value into the low `P` bits. The class bit is `polarity.element_class`, so nulls collect on the
+ * requested side of every value in their segment; a null zeroes the prefix bits so all nulls in a
+ * segment share one key (their order is immaterial and their bytes never read). A descending sort
+ * complements only the `P` prefix bits, reversing their unsigned order without reaching the class
+ * or segment fields -- so the same key drives every (order, null_order) combination.
+ */
+struct packed_key_builder {
+  size_type const* d_segment_ids;
+  column_device_view const d_strings;
+  bool const has_nulls;
+  packed_key_layout const layout;
+  sort_polarity const polarity;
+  __device__ cuda::std::uint64_t operator()(size_type idx) const
+  {
+    auto const segment_id   = static_cast<cuda::std::uint64_t>(d_segment_ids[idx]);
+    auto const segment_part = segment_id << (64 - layout.segment_bits);
+    if (has_nulls && d_strings.is_null(idx)) {
+      return segment_part |
+             (static_cast<cuda::std::uint64_t>(polarity.element_class(true)) << layout.prefix_bits);
+    }
+    auto const d_str                = d_strings.element<string_view>(idx);
+    auto const bytes                = d_str.size_bytes();
+    auto const* ptr                 = reinterpret_cast<unsigned char const*>(d_str.data());
+    auto const packed_bytes         = cuda::std::min(bytes, size_type{prefix_bytes});
+    cuda::std::uint64_t full_prefix = 0;
+    for (size_type i = 0; i < packed_bytes; ++i) {
+      full_prefix |= static_cast<cuda::std::uint64_t>(ptr[i]) << (56 - i * 8);
+    }
+    // Keep only the top P bits of the eight-byte big-endian prefix; the low bits do not fit.
+    // Descending complements just those P bits (`value_mask64` narrowed to a P-bit mask), reversing
+    // their order while staying below the class bit.
+    auto const prefix = (full_prefix >> (64 - layout.prefix_bits)) ^
+                        (polarity.value_mask64() >> (64 - layout.prefix_bits));
+    // When `has_nulls` is false the layout reserves no class bit, so `prefix_bits` coincides with
+    // the segment field's LSB and this class OR is provably zero: callers must resolve
+    // `nulls_first == false` for a null-free column (the fast-path gates do), and
+    // `element_class(false) == nulls_first`.
+    return segment_part |
+           (static_cast<cuda::std::uint64_t>(polarity.element_class(false)) << layout.prefix_bits) |
+           prefix;
+  }
+};
+
+/**
+ * @brief Flags the first position of each maximal run of equal `uint64` keys (1 = head, else 0)
+ *
+ * The `uint64` analogue of `key_head_flag`: an inclusive sum of these flags yields the dense
+ * one-based run rank that seeds the iterative window path, capturing exactly the order the first
+ * `uint64` sort resolved (the `P` packed bits) -- never the unencoded low bits -- so two strings
+ * tied on the packed key are left in one run for the windows to resolve rather than frozen apart.
+ */
+struct key_head_flag_packed {
+  cuda::std::uint64_t const* d_keys;
+  __device__ cuda::std::uint32_t operator()(size_type i) const
+  {
+    if (i == 0) { return 1u; }
+    return d_keys[i - 1] != d_keys[i] ? 1u : 0u;
+  }
+};
+
+/**
+ * @brief Flags `uint64`-key positions equal to a neighbor (a run of two or more), never a null
+ *
+ * The `uint64` analogue of `key_tied_flag`, used once to size and gate the iterative tie-break:
+ * only these positions still need reordering. A null element is position-final after the first pass
+ * -- its class bit sorts it to the polarity's side within the segment -- and its order among nulls
+ * is immaterial, so it is reported untied and left in its first-pass slot rather than dragged
+ * through every window only to be skipped by the cleanup. `null_flag` is the class-bit value that
+ * marks a null (`polarity.element_class(true)`: 1 nulls-last, 0 nulls-first); the bit sits at
+ * `prefix_bits` and is present only when the column has nulls.
+ */
+struct key_tied_flag_packed {
+  cuda::std::uint64_t const* d_keys;
+  size_type const num_elements;
+  bool const has_nulls;
+  int const prefix_bits;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const cur = d_keys[i];
+    if (has_nulls && static_cast<cuda::std::uint32_t>((cur >> prefix_bits) & 1u) == null_flag) {
+      return false;
+    }
+    auto const eq_prev = i > 0 && d_keys[i - 1] == cur;
+    auto const eq_next = i + 1 < num_elements && d_keys[i + 1] == cur;
+    return eq_prev || eq_next;
+  }
+};
+
+/**
+ * @brief Big-endian packs a string's eight bytes starting at `window_start` into a `uint64`
+ *
+ * Mirrors `packed_key_builder`'s packing (byte 0 of the window in the most-significant position,
+ * trailing bytes zero-filled) but at an arbitrary `window_start`, so an unsigned comparison of the
+ * result reproduces unsigned-byte lexicographic order over that eight-byte window. A string with no
+ * bytes at or past `window_start` packs to zero -- the minimum -- so an exhausted (shorter) string
+ * orders before any string still carrying bytes in the window, reproducing the shorter-is-less
+ * length tie-break for that window. A descending sort complements the returned window at the call
+ * site, sending that exhausted zero to the maximum so the shorter string instead orders last -- the
+ * exact reverse. Null elements are never inspected here.
+ */
+__device__ inline cuda::std::uint64_t pack_window(string_view const& d_str, size_type window_start)
+{
+  auto const bytes = d_str.size_bytes();
+  if (window_start >= bytes) { return 0; }
+  auto const* ptr = reinterpret_cast<unsigned char const*>(d_str.data());
+  // Value copy: ODR-using the prefix_bytes constexpr by reference is ill-formed in device code.
+  auto const window_bytes    = cuda::std::min(bytes - window_start, size_type{prefix_bytes});
+  cuda::std::uint64_t window = 0;
+  for (size_type i = 0; i < window_bytes; ++i) {
+    window |= static_cast<cuda::std::uint64_t>(ptr[window_start + i]) << (56 - i * 8);
+  }
+  return window;
+}
+
+/**
+ * @brief Per-run string-length range: the minimum and maximum byte length over a run of tied keys
+ *
+ * Reduced across each run of equal keys to decide whether the run is byte-identical. A run that is
+ * length-uniform (`min_len == max_len`) and fully covered by the windows compared so far holds only
+ * copies of one string, so its order is already final; a mixed-length run is a zero-extension
+ * family (a shorter string colliding with a longer one's real or zero-filled bytes) that the
+ * comparison cleanup must still order shorter-first.
+ */
+struct len_minmax {
+  size_type min_len;
+  size_type max_len;
+};
+
+/// Combines two `len_minmax` ranges: min of the minima and max of the maxima. Associative and
+/// commutative, as `reduce_by_key` requires.
+struct len_minmax_combine {
+  __device__ len_minmax operator()(len_minmax const& a, len_minmax const& b) const
+  {
+    return len_minmax{cuda::std::min(a.min_len, b.min_len), cuda::std::max(a.max_len, b.max_len)};
+  }
+};
+
+/// Seeds each active element's byte length as a degenerate `[len, len]` range for the per-run
+/// reduction. The active set never holds a null (the tie gate excludes them), so the child index
+/// always names a real string.
+struct string_length_minmax {
+  size_type const* d_children;
+  column_device_view const d_strings;
+  __device__ len_minmax operator()(size_type i) const
+  {
+    auto const len = d_strings.element<string_view>(d_children[i]).size_bytes();
+    return len_minmax{len, len};
+  }
+};
+
+/**
+ * @brief First-pass tie flag refined to drop byte-identical exhausted runs
+ *
+ * Extends `key_tied_flag_packed`: a position stays tied only if it is in a packed-key run of two or
+ * more that is not already byte-identical. A run whose lengths are uniform (`min == max`) and no
+ * greater than `known_equal_bytes` -- the whole bytes the packed key proves equal -- holds one
+ * repeated string, so every copy is position-final at its stable first-pass slot and is excluded
+ * from the tie set entirely, sparing the loop and its O(N) buffers. A mixed-length run stays: a
+ * shorter string can share a longer one's packed key through the zero-fill, and only the cleanup
+ * can order it.
+ *
+ * The drop is polarity-independent: length uniformity reads real byte lengths, not the (possibly
+ * complemented) key, and a run is a set of equal keys under either order (the complement is a
+ * bijection), so a uniform-length run within the covered bytes is byte-identical duplicates whose
+ * shared slot is final under any order. The rule only chooses which runs skip the cleanup; the kept
+ * mixed-length runs get the polarity-aware ordering there. `null_flag` matches
+ * `key_tied_flag_packed`.
+ */
+struct keep_tied_first {
+  cuda::std::uint64_t const* d_keys;
+  size_type const num_elements;
+  bool const has_nulls;
+  int const prefix_bits;
+  cuda::std::uint32_t const* d_run_ids;
+  len_minmax const* d_run_minmax;
+  size_type const known_equal_bytes;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const cur = d_keys[i];
+    if (has_nulls && static_cast<cuda::std::uint32_t>((cur >> prefix_bits) & 1u) == null_flag) {
+      return false;
+    }
+    auto const eq_prev = i > 0 && d_keys[i - 1] == cur;
+    auto const eq_next = i + 1 < num_elements && d_keys[i + 1] == cur;
+    if (!(eq_prev || eq_next)) { return false; }
+    auto const mm        = d_run_minmax[d_run_ids[i] - 1];
+    auto const identical = mm.min_len == mm.max_len && mm.max_len <= known_equal_bytes;
+    return !identical;
+  }
+};
+
+/**
+ * @brief Window-loop tie flag refined to drop byte-identical exhausted runs
+ *
+ * Extends `key_tied_flag`: an active position stays tied only if it is in a run of two or more that
+ * is not yet byte-identical. `covered` is the leading bytes every element in a run agrees on after
+ * this pass (the windows compared so far). A length-uniform run (`min == max`) whose common length
+ * is no greater than `covered` holds only copies of one string -- equal window stream over its
+ * whole length and equal length -- so its stable radix order is final and it is frozen like a
+ * singleton. A mixed-length run is a zero-extension family kept for the length-aware comparison
+ * cleanup. The drop is polarity-independent for the same reason as `keep_tied_first`:
+ * uniform-length covered runs are byte-identical duplicates under either order. `null_flag` is the
+ * class-bit value marking a null (`polarity.element_class(true)`).
+ */
+struct keep_active_window {
+  prefix_key96 const* d_keys;
+  size_type const num_elements;
+  cuda::std::uint32_t const* d_run_ids;
+  len_minmax const* d_run_minmax;
+  size_type const covered;
+  cuda::std::uint32_t const null_flag = 1u;
+  __device__ bool operator()(size_type i) const
+  {
+    auto const cur = d_keys[i];
+    if ((cur.seg_null & 1u) == null_flag) { return false; }
+    auto const eq_prev = i > 0 && keys_equal(d_keys[i - 1], cur);
+    auto const eq_next = i + 1 < num_elements && keys_equal(d_keys[i + 1], cur);
+    if (!(eq_prev || eq_next)) { return false; }
+    auto const mm        = d_run_minmax[d_run_ids[i] - 1];
+    auto const identical = mm.min_len == mm.max_len && mm.max_len <= covered;
+    return !identical;
+  }
+};
+
+/**
+ * @brief Builds the next-pass radix key for the element currently at a sorted position
+ *
+ * The key reuses the `prefix_key96` layout: `seg_null` packs the run rank in its high 31 bits (the
+ * dominant field, so radixing by it preserves all order resolved by prior passes) and the
+ * polarity's class bit in bit 0, and the two window words hold the next eight-byte string window.
+ * Two elements sharing a run rank are still tied; the window refines their order without disturbing
+ * any other run. Null elements are isolated by the run rank (the class bit rides it), so the rank
+ * alone keeps them grouped on the polarity's side; they carry the class bit and an unread window,
+ * so the comparison cleanup recognizes and skips the run exactly as it does for the first pass. A
+ * descending sort complements the window (`value_mask64`), reversing byte order and sending an
+ * exhausted zero window to the maximum so a shorter string sorts after the longer ones sharing its
+ * prefix; the run rank and class bit stay ascending.
+ */
+struct window_key_builder {
+  cuda::std::uint32_t const* d_run_ids;
+  size_type const* d_sorted_indices;
+  column_device_view const d_strings;
+  bool const has_nulls;
+  size_type const window_start;
+  sort_polarity const polarity;
+  __device__ prefix_key96 operator()(size_type i) const
+  {
+    auto const run_id = d_run_ids[i];
+    auto const idx    = d_sorted_indices[i];
+    if (has_nulls && d_strings.is_null(idx)) {
+      return prefix_key96{pack_seg_null(run_id, polarity.element_class(true)), 0u, 0u};
+    }
+    prefix_key96 key{pack_seg_null(run_id, polarity.element_class(false)), 0u, 0u};
+    split_prefix(
+      pack_window(d_strings.element<string_view>(idx), window_start) ^ polarity.value_mask64(),
+      key.prefix_hi,
+      key.prefix_lo);
+    return key;
+  }
+};
+
+/**
+ * @brief Seeds the iterative window path's first-pass key from the single-`uint64` first sort
+ *
+ * The window path keys on `prefix_key96` and recomputes the run rank from its `cur_keys` at the top
+ * of every pass, so its seed must be a `prefix_key96` whose run boundaries match exactly what the
+ * first `uint64` sort resolved -- the `P` packed bits -- and nothing finer. This emits a key whose
+ * `seg_null` packs the dense rank via `pack_seg_null` (reproducing the packed boundaries when
+ * head-flagged) and whose window words are zero (adding no spurious boundary). The null flag read
+ * from the packed key is carried for consistency, though the count-first tie set already excludes
+ * nulls. The first window is built fresh by the pass itself; carrying a window here instead would
+ * let two strings tied on the packed key but differing within that window be split into distinct
+ * ranks, freezing an arbitrary order the windows must still be free to refine.
+ */
+struct tied_run_seed_builder {
+  cuda::std::uint32_t const* d_run_ids;
+  cuda::std::uint64_t const* d_packed_keys;
+  int const prefix_bits;
+  bool const has_nulls;
+  __device__ prefix_key96 operator()(size_type i) const
+  {
+    auto const is_null =
+      has_nulls ? static_cast<cuda::std::uint32_t>((d_packed_keys[i] >> prefix_bits) & 1u) : 0u;
+    return prefix_key96{pack_seg_null(d_run_ids[i], is_null), 0u, 0u};
+  }
+};
+
+/**
+ * @brief Unsigned-byte comparison of two strings starting at a shared byte offset
+ *
+ * Replicates `string_view::compare` while skipping the first `offset` bytes, which the caller has
+ * already proven equal. Each string's compared region runs from `offset` to its end (empty when the
+ * string is no longer than `offset`); the bytes are compared unsigned. On an all-equal common
+ * region the result is the full-length difference, which -- because the skipped prefixes are equal
+ * -- carries the same sign as `string_view::compare`'s own length tie-break, including when one or
+ * both strings are no longer than `offset` (e.g. distinguishing a string from itself plus a
+ * trailing embedded null). This reproduces `string_view::compare` exactly for any pair whose first
+ * `offset` bytes match, since that comparison would consume those equal bytes with no effect before
+ * reaching the same suffixes.
+ */
+__device__ inline int compare_suffix(string_view const& a, string_view const& b, size_type offset)
+{
+  auto const a_len = cuda::std::max(0, a.size_bytes() - offset);
+  auto const b_len = cuda::std::max(0, b.size_bytes() - offset);
+  auto const* pa =
+    reinterpret_cast<unsigned char const*>(a.data()) + cuda::std::min(offset, a.size_bytes());
+  auto const* pb =
+    reinterpret_cast<unsigned char const*>(b.data()) + cuda::std::min(offset, b.size_bytes());
+  auto const common = cuda::std::min(a_len, b_len);
+  for (size_type i = 0; i < common; ++i) {
+    if (pa[i] != pb[i]) { return static_cast<int>(pa[i]) - static_cast<int>(pb[i]); }
+  }
+  return a.size_bytes() - b.size_bytes();
+}
+
+/**
+ * @brief Run length at or above which a prefix-tie run is sorted by heapsort instead of insertion
+ *
+ * Insertion sort is optimal for the tiny runs typical of high-cardinality data, but it is O(run^2):
+ * a fully-shared-prefix segment collapses to one run spanning the whole segment, which on the
+ * generator's outlier rows of thousands of elements turns the tie-break into a multi-second
+ * straggler. Switching to O(run*log run) heapsort once a run reaches this size caps that worst case
+ * while leaving the common tiny-run path untouched.
+ */
+constexpr size_type TIE_HEAPSORT_THRESHOLD = 32;
+
+/**
+ * @brief Maximum number of iterative eight-byte radix windows after the initial prefix pass
+ *
+ * Each iterative pass resolves another eight bytes of strings still tied on every byte ordered so
+ * far, so the loop terminates once every surviving run is length-uniform and exhausted (its bytes
+ * fully consumed with no length difference left) or once all runs are singletons. This cap bounds
+ * the worst case -- strings sharing an arbitrarily
+ * long leading run (e.g. thousands agreeing on a multi-kilobyte prefix) would otherwise demand one
+ * pass per eight shared bytes. Eight windows clears 64 bytes past the initial prefix; whatever
+ * remains tied is finished by a single comparison cleanup, so correctness never depends on the cap,
+ * only the pass count does.
+ */
+constexpr size_type MAX_RADIX_PASSES = 8;
+
+/**
+ * @brief Reorders prefix-tied runs by suffix comparison to match the comparison sort exactly
+ *
+ * The prefix orders only the leading bytes, so distinct strings in one segment sharing those bytes
+ * carry an equal `prefix_key96` that the radix sort cannot separate. After the radix sort, each
+ * maximal run of consecutive equal keys is owned by its first position, which sorts the run's child
+ * indices by comparing the bytes from `tie_offset` onward. Genuine duplicates compare equal so
+ * their order is immaterial, and an all-null run carries the null flag in `seg_null` and is left
+ * untouched (its elements are null and never compared). The comparison uses unsigned-byte ordering,
+ * matching the lexicographic comparison path, so the result is identical. `tie_offset` is the width
+ * of the shared prefix the run agrees on, so the comparison skips those bytes and orders by the
+ * remainder.
+ *
+ * Tiny runs (the common case on high-cardinality data) use an insertion sort; runs reaching
+ * `TIE_HEAPSORT_THRESHOLD` use a heapsort instead, so a fully-shared-prefix run spanning a whole
+ * segment cannot drive the single-threaded tie-break quadratic. Both sort in the requested
+ * direction under the same suffix comparator and yield the same order; the path is unstable, so the
+ * heapsort's reordering of equal elements is immaterial.
+ *
+ * Direction invariant: the cleanup must reproduce the order the window keys were driving toward for
+ * the runs it refines. Ascending takes `compare_suffix` directly; descending inverts its sign,
+ * which reverses both the byte comparison and the length tie-break -- matching the descending
+ * window keys (whose exhausted-zero-to-maximum complement already ordered a shorter string last).
+ * `null_flag` is the class-bit value marking a null run (`polarity.element_class(true)`); such runs
+ * hold only nulls, are never compared, and are left in place -- and none reach here, the tie gate
+ * excludes them.
+ */
+struct prefix_tie_breaker {
+  prefix_key96 const* d_keys;
+  size_type* d_indices;
+  column_device_view const d_strings;
+  size_type const num_elements;
+  size_type const tie_offset;
+  bool const descending               = false;
+  cuda::std::uint32_t const null_flag = 1u;
+
+  // True when the string referenced by index `a` orders strictly before the one referenced by `b`
+  // in the requested direction -- the "less than" the run is sorted by. Descending inverts the
+  // suffix comparison's sign (see the direction invariant above).
+  __device__ bool index_less(size_type a, size_type b) const
+  {
+    auto const cmp = compare_suffix(
+      d_strings.element<string_view>(a), d_strings.element<string_view>(b), tie_offset);
+    return descending ? cmp > 0 : cmp < 0;
+  }
+
+  // Sift the element at local position `root` down a max-heap of size `n` over the run starting at
+  // `base`, restoring the heap property below `root`.
+  __device__ void sift_down(size_type* base, int64_t root, int64_t n) const
+  {
+    while (true) {
+      auto const left = 2 * root + 1;
+      if (left >= n) { break; }
+      auto largest     = left;
+      auto const right = left + 1;
+      if (right < n && index_less(base[left], base[right])) { largest = right; }
+      if (!index_less(base[root], base[largest])) { break; }
+      auto const tmp = base[root];
+      base[root]     = base[largest];
+      base[largest]  = tmp;
+      root           = largest;
+    }
+  }
+
+  __device__ void operator()(size_type i) const
+  {
+    // Only the first position of a run does the work; runs are disjoint so writes never overlap.
+    auto const key = d_keys[i];
+    if (i > 0 && keys_equal(d_keys[i - 1], key)) { return; }
+    // A null-classed run is entirely null elements, whose order is immaterial and whose string data
+    // must not be read. The class bit is bit 0 of `seg_null`; `null_flag` is its null value.
+    if ((key.seg_null & 1u) == null_flag) { return; }
+
+    auto run_end = i + 1;
+    while (run_end < num_elements && keys_equal(d_keys[run_end], key)) {
+      ++run_end;
+    }
+    auto const run_len = run_end - i;
+    if (run_len < 2) { return; }
+
+    // Bytes before `tie_offset` are skipped since the run agrees on them.
+    if (run_len < TIE_HEAPSORT_THRESHOLD) {
+      // Insertion sort: optimal for the tiny runs typical of high-cardinality data, where ties are
+      // rare.
+      for (auto j = i + 1; j < run_end; ++j) {
+        auto const idx_j = d_indices[j];
+        auto const str_j = d_strings.element<string_view>(idx_j);
+        auto k           = j;
+        while (k > i) {
+          auto const cmp =
+            compare_suffix(d_strings.element<string_view>(d_indices[k - 1]), str_j, tie_offset);
+          // Shift a neighbor that must follow `str_j`: ascending shifts a greater neighbor,
+          // descending a smaller one.
+          if (!(descending ? cmp < 0 : cmp > 0)) { break; }
+          d_indices[k] = d_indices[k - 1];
+          --k;
+        }
+        d_indices[k] = idx_j;
+      }
+    } else {
+      // Heapsort: O(run*log run) and O(1) extra memory, capping the worst case when a shared prefix
+      // makes one run span the whole segment. Build a max-heap, then repeatedly move the maximum to
+      // the shrinking tail, which leaves the run ascending.
+      auto* const base = d_indices + i;
+      for (auto start = run_len / 2; start > 0; --start) {
+        sift_down(base, start - 1, run_len);
+      }
+      for (auto heap_size = run_len; heap_size > 1; --heap_size) {
+        auto const tmp      = base[0];
+        base[0]             = base[heap_size - 1];
+        base[heap_size - 1] = tmp;
+        sift_down(base, 0, heap_size - 1);
+      }
+    }
+  }
+};
+
+}  // namespace
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_prefix(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+
+  // The packed key reserves a class bit only when nullable (see `packed_key_builder`); guard the
+  // caller-side coupling so a null-free column can never arrive with nulls_first set.
+  CUDF_EXPECTS(input.has_nulls() or not polarity.nulls_first,
+               "nulls_first requires a nullable column for the packed key layout");
+
+  // Label every element with its dense segment ordinal (`0, 1, ...` across the segments) so a
+  // single global radix sort orders within each segment. Unlike the offset-derived labels the
+  // shared `get_segment_indices` produces (whose values range up to the row count), these ordinals
+  // range only over the segment count, so the packed key's segment field needs just
+  // `bit_width(num_segments)` bits -- freeing the rest for a wider prefix. The ordinals are
+  // monotonic with the segments (empty segments contribute no element and simply skip a label), so
+  // cross-segment order is preserved exactly. The strings path's offsets are normalized to span
+  // `[0, num_elements]`, so the label output size is `num_elements`.
+  rmm::device_uvector<size_type> segment_ids(num_elements, stream);
+  label_segments(segment_offsets.begin<size_type>(),
+                 segment_offsets.end<size_type>(),
+                 segment_ids.begin(),
+                 segment_ids.end(),
+                 stream);
+
+  auto const d_input   = column_device_view::create(input, stream);
+  auto const has_nulls = input.has_nulls();
+
+  // The single-uint64 first-pass key layout. The segment labels are dense ordinals bounded by the
+  // segment count, so the high field is sized for the largest possible ordinal (num_segments - 1)
+  // via num_segments; the leftover bits below the optional null bit hold the prefix -- wider here
+  // than under a row-count bound, so the key distinguishes more leading bytes before a tie.
+  auto const layout = make_packed_key_layout(num_segments, has_nulls);
+  // Whole leading bytes the packed key proves equal once two keys match. Only floor(P/8) full bytes
+  // are guaranteed -- the partial trailing bits of P say nothing about the next byte -- so the
+  // windows and the comparison cleanup must begin here rather than at a fixed eight.
+  auto const known_equal_bytes = layout.prefix_bits / 8;
+
+  auto const counting = cuda::counting_iterator<size_type>{0};
+
+  // First-pass outputs. They outlive the packed-key inputs, which are scoped to the sort below and
+  // freed before the tie loop grows its working set.
+  rmm::device_uvector<cuda::std::uint64_t> keys_out(num_elements, stream);
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+  auto const d_indices_out = sorted_indices->mutable_view().begin<size_type>();
+
+  // The iterative window path keys on the 96-bit `prefix_key96` {run rank, eight-byte window},
+  // decomposed into its fields; `key_bits` is that key's width. `seg_null` packs the run rank in
+  // bits 1..31 and a null flag in bit 0; the run rank comes from a scan over run heads and is
+  // bounded by the element count, itself a `size_type`, so `(rank << 1) | flag` fits the 32-bit
+  // field for every `size_type` value -- proven once here rather than guarded per element.
+  static_assert(2ull * cuda::std::numeric_limits<size_type>::max() + 1ull <=
+                  cuda::std::numeric_limits<cuda::std::uint32_t>::max(),
+                "size_type run rank does not fit prefix_key96::seg_null after the null-flag shift");
+  auto const decomposer   = prefix_decomposer{};
+  auto constexpr key_bits = static_cast<int>(
+    (sizeof(cuda::std::uint32_t) + sizeof(cuda::std::uint32_t) + sizeof(cuda::std::uint32_t)) * 8);
+
+  // First pass: one global radix sort of the single-uint64 key, carrying child indices as the
+  // paired values. The unsigned-key compare sorts by segment, then non-nulls before nulls, then by
+  // the packed leading bytes -- the same order the iterative `prefix_key96` produces. The whole
+  // word is significant (segment in the high bits, prefix filling the low bits with no zero
+  // padding), so the range is the full [0, 64): eight byte-passes, not the twelve the 96-bit
+  // iterative key would need. The inputs and the two-stage temporary storage are all scoped here,
+  // so they are released before the tie loop.
+  {
+    rmm::device_uvector<cuda::std::uint64_t> keys_in(num_elements, stream);
+    rmm::device_uvector<size_type> indices_in(num_elements, stream);
+    thrust::transform(
+      rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+      counting,
+      counting + num_elements,
+      keys_in.begin(),
+      packed_key_builder{segment_ids.data(), *d_input, has_nulls, layout, polarity});
+    thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     indices_in.begin(),
+                     indices_in.end(),
+                     0);
+    rmm::device_buffer d_temp_storage;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    indices_in.data(),
+                                    d_indices_out,
+                                    num_elements,
+                                    0,
+                                    static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                    stream.value());
+    d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+    cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    keys_in.data(),
+                                    keys_out.data(),
+                                    indices_in.data(),
+                                    d_indices_out,
+                                    num_elements,
+                                    0,
+                                    static_cast<int>(sizeof(cuda::std::uint64_t) * 8),
+                                    stream.value());
+  }
+
+  // `segment_ids` fed only the first-pass key build above; free it (stream-ordered) before the tie
+  // path grows its working set, mirroring the `keys_out` release after the seed block below.
+  segment_ids = rmm::device_uvector<size_type>{0, stream};
+
+  // Count-first zero-tie gate. A single O(N) pass over the sorted first-pass keys reports how many
+  // elements are still tied (a run of two or more sharing the packed key, nulls excluded). Reading
+  // that count is the one host synchronization the tie-break adds -- the same D->H read the old
+  // flag-then-compact ordering already paid. On high-cardinality data nothing is tied, so it
+  // returns zero and allocates no tie buffer, runs no compaction, and skips the loop and cleanup:
+  // the common path is the first pass plus this single count.
+  auto const tied_pred = key_tied_flag_packed{
+    keys_out.data(), num_elements, has_nulls, layout.prefix_bits, polarity.element_class(true)};
+  auto const any_tied =
+    thrust::count_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     counting,
+                     counting + num_elements,
+                     tied_pred) > 0;
+
+  if (any_tied) {
+    // First-key length-uniform-exhausted exclusion. `tied_flags` starts from the raw packed-key
+    // ties, then drops any run that is already byte-identical: a packed-key run whose lengths are
+    // uniform and no greater than `known_equal_bytes` holds one repeated string, so every copy is
+    // position-final at its stable first-pass slot and never needs the loop or its O(N) buffers.
+    // The per-run length range is reduced only here, on the tie path -- the zero-tie gate above
+    // already short-circuited the common case, and the N-wide range temporaries are freed before
+    // the loop. A mixed-length run stays: a shorter string can share a longer one's packed key
+    // through the zero-fill, so only the comparison cleanup can order it.
+    rmm::device_uvector<bool> tied_flags(num_elements, stream);
+    {
+      rmm::device_uvector<cuda::std::uint32_t> first_run_ids(num_elements, stream);
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_elements,
+                        first_run_ids.begin(),
+                        key_head_flag_packed{keys_out.data()});
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      first_run_ids.data(),
+                                      first_run_ids.data(),
+                                      num_elements,
+                                      stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      first_run_ids.data(),
+                                      first_run_ids.data(),
+                                      num_elements,
+                                      stream.value());
+      }
+      rmm::device_uvector<len_minmax> first_elem_minmax(num_elements, stream);
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_elements,
+                        first_elem_minmax.begin(),
+                        string_length_minmax{d_indices_out, *d_input});
+      rmm::device_uvector<len_minmax> first_run_minmax(num_elements, stream);
+      thrust::reduce_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        first_run_ids.begin(),
+        first_run_ids.end(),
+        first_elem_minmax.begin(),
+        cuda::make_discard_iterator(),
+        first_run_minmax.begin(),
+        cuda::std::equal_to<cuda::std::uint32_t>{},
+        len_minmax_combine{});
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_elements,
+                        tied_flags.begin(),
+                        keep_tied_first{keys_out.data(),
+                                        num_elements,
+                                        has_nulls,
+                                        layout.prefix_bits,
+                                        first_run_ids.data(),
+                                        first_run_minmax.data(),
+                                        known_equal_bytes,
+                                        polarity.element_class(true)});
+    }
+
+    // Compact the sorted order down to just the still-tied positions; resolved singletons, untied
+    // segments, byte-identical runs, and nulls are already in their final place and excluded, so
+    // the windows and cleanup re-sort only this shrinking subset rather than the whole column.
+    // `comp_pos` records each tied element's output position so the refined order can be scattered
+    // straight back. The compacted outputs are sized to the refined tie count; `tied_flags` stays
+    // N-sized because the selection reads a flag per input element.
+    auto const num_tied = static_cast<size_type>(
+      thrust::count(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    tied_flags.begin(),
+                    tied_flags.end(),
+                    true));
+
+    // `tied_keys_packed` holds the still-tied elements' packed keys -- it feeds only the seed run
+    // rank below (capturing exactly the order the first sort resolved); the iterative loop then
+    // keys on the 96-bit `prefix_key96` it builds in `tied_keys_a`.
+    rmm::device_uvector<size_type> comp_pos(num_tied, stream);
+    rmm::device_uvector<size_type> child_a(num_tied, stream);
+    rmm::device_uvector<cuda::std::uint64_t> tied_keys_packed(num_tied, stream);
+    rmm::device_uvector<prefix_key96> tied_keys_a(num_tied, stream);
+    cudf::detail::device_scalar<size_type> d_num_tied(stream);
+
+    // Each flagged compaction gathers the tied positions, their child indices, or their packed
+    // keys. The count is already known, so `d_num_tied` here only satisfies the API; it is re-read
+    // per pass inside the loop where the surviving count changes.
+    auto const select_flagged = [&](auto d_in, auto* d_out) {
+      rmm::device_buffer d_temp_storage;
+      size_t temp_storage_bytes = 0;
+      cub::DeviceSelect::Flagged(d_temp_storage.data(),
+                                 temp_storage_bytes,
+                                 d_in,
+                                 tied_flags.data(),
+                                 d_out,
+                                 d_num_tied.data(),
+                                 num_elements,
+                                 stream.value());
+      d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+      cub::DeviceSelect::Flagged(d_temp_storage.data(),
+                                 temp_storage_bytes,
+                                 d_in,
+                                 tied_flags.data(),
+                                 d_out,
+                                 d_num_tied.data(),
+                                 num_elements,
+                                 stream.value());
+    };
+    select_flagged(counting, comp_pos.data());
+    select_flagged(d_indices_out, child_a.data());
+    select_flagged(keys_out.data(), tied_keys_packed.data());
+    // `keys_out` is now fully captured -- its ties seeded into `tied_keys_packed` and its
+    // singletons already in their final slots -- so free the N-wide first-pass keys before the
+    // loop's working set peaks.
+    keys_out = rmm::device_uvector<cuda::std::uint64_t>{0, stream};
+
+    // Iterative deepening over the compacted tied set only. `cur_keys`/`cur_child` hold the current
+    // sorted keys and child indices of the still-tied elements; each pass computes a dense run rank
+    // from those keys, builds the next key as {run rank, next 8-byte window}, and radixes just the
+    // tied subset by it. The run rank is the most-significant field, so the sort fixes every
+    // element already separated by an earlier window and only reorders within a still-tied run. The
+    // first `known_equal_bytes` bytes were ordered by the first pass, so windows start there and
+    // advance eight bytes.
+    //
+    // After each pass the elements that became singletons are scattered to their final output slots
+    // and dropped from the working set, so the next pass radixes only the shrinking remainder
+    // rather than the full `num_tied` set. A singleton owns a unique run rank, so no later window
+    // can move it: its order is final the moment it separates. The loop stops as soon as nothing
+    // stays tied, turning a shared prefix that resolves in one window into one pass instead of the
+    // full cap.
+    //
+    // `cur_pos` holds the still-tied output slots and is kept ascending: each pass the element at
+    // sorted position p belongs at the p-th remaining slot, so the slots are paired with the sorted
+    // children by position and are only compacted (never permuted) -- compaction drops the slots of
+    // frozen singletons and leaves the survivors' slots in ascending order. Permuting the slots by
+    // the sort would misassign them, so the radix reorders only the keys and children.
+    rmm::device_uvector<size_type> child_b(num_tied, stream);
+    rmm::device_uvector<prefix_key96> tied_keys_b(num_tied, stream);
+    rmm::device_uvector<size_type> pos_b(num_tied, stream);
+    rmm::device_uvector<cuda::std::uint32_t> run_ids(num_tied, stream);
+    // Per-active-element length range and its per-run reduction, reused each pass to spot runs that
+    // have become byte-identical (see `keep_active_window`). Sized to the initial tie count like
+    // the other scratch; only the active prefix is touched per pass.
+    rmm::device_uvector<len_minmax> elem_minmax(num_tied, stream);
+    rmm::device_uvector<len_minmax> run_minmax(num_tied, stream);
+
+    // Seed `tied_keys_a` so the loop's first head-flag reproduces exactly the runs the uint64 sort
+    // left tied: a dense run rank over the compacted packed keys, packed back into a `prefix_key96`
+    // carrying that rank and the null flag but no window. The first window is built by the pass
+    // itself; embedding one here would over-split packed-key ties (see `tied_run_seed_builder`).
+    {
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_tied,
+                        run_ids.begin(),
+                        key_head_flag_packed{tied_keys_packed.data()});
+      rmm::device_buffer d_temp_storage;
+      size_t temp_storage_bytes = 0;
+      cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    run_ids.data(),
+                                    run_ids.data(),
+                                    num_tied,
+                                    stream.value());
+      d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+      cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                    temp_storage_bytes,
+                                    run_ids.data(),
+                                    run_ids.data(),
+                                    num_tied,
+                                    stream.value());
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_tied,
+                        tied_keys_a.begin(),
+                        tied_run_seed_builder{
+                          run_ids.data(), tied_keys_packed.data(), layout.prefix_bits, has_nulls});
+    }
+
+    auto* cur_keys      = tied_keys_a.data();
+    auto* nxt_keys      = tied_keys_b.data();
+    auto* cur_child     = child_a.data();
+    auto* nxt_child     = child_b.data();
+    auto* cur_pos       = comp_pos.data();
+    auto* nxt_pos       = pos_b.data();
+    auto consumed_bytes = known_equal_bytes;
+    auto num_active     = num_tied;
+    for (size_type pass = 0; pass < MAX_RADIX_PASSES && num_active > 0; ++pass) {
+      // Dense one-based run rank over the active subset: a key change starts a new run, so an
+      // inclusive sum of head flags gives a rank identical within a run and rising across runs.
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        run_ids.begin(),
+                        key_head_flag{cur_keys});
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      run_ids.data(),
+                                      run_ids.data(),
+                                      num_active,
+                                      stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      run_ids.data(),
+                                      run_ids.data(),
+                                      num_active,
+                                      stream.value());
+      }
+
+      // Build the next key {run rank, next eight bytes} for each active element, then radix the
+      // active subset by it. All 96 bits are significant: the run rank and null flag fill the high
+      // 32-bit seg_null field and the eight-byte window the low 64 bits (prefix_hi then prefix_lo).
+      // The current child indices feed back as the paired values.
+      thrust::transform(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        counting,
+        counting + num_active,
+        nxt_keys,
+        window_key_builder{
+          run_ids.data(), cur_child, *d_input, has_nulls, consumed_bytes, polarity});
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        nxt_keys,
+                                        cur_keys,
+                                        cur_child,
+                                        nxt_child,
+                                        num_active,
+                                        decomposer,
+                                        0,
+                                        key_bits,
+                                        stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceRadixSort::SortPairs(d_temp_storage.data(),
+                                        temp_storage_bytes,
+                                        nxt_keys,
+                                        cur_keys,
+                                        cur_child,
+                                        nxt_child,
+                                        num_active,
+                                        decomposer,
+                                        0,
+                                        key_bits,
+                                        stream.value());
+      }
+      // The radix wrote the sorted keys into `cur_keys` and the sorted child indices into
+      // `nxt_child`; swap so `cur_child` names the sorted indices and the old one becomes scratch.
+      cuda::std::swap(cur_child, nxt_child);
+
+      // Decide which active positions stay tied under the refreshed order. A position is dropped
+      // when it is a singleton (its key differs from both neighbors, so its order is final) or when
+      // its run has become byte-identical: length-uniform with a common length no greater than the
+      // bytes the windows have now covered, so every element is a copy of one string and the stable
+      // radix order is already correct. The per-run length range is reduced over a dense post-sort
+      // run rank; a mixed-length run (a zero-extension family) is kept for the length-aware
+      // cleanup. `covered` is `consumed_bytes` plus this pass's window -- the bytes a run now
+      // agrees on.
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        elem_minmax.begin(),
+                        string_length_minmax{cur_child, *d_input});
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        run_ids.begin(),
+                        key_head_flag{cur_keys});
+      {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      run_ids.data(),
+                                      run_ids.data(),
+                                      num_active,
+                                      stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceScan::InclusiveSum(d_temp_storage.data(),
+                                      temp_storage_bytes,
+                                      run_ids.data(),
+                                      run_ids.data(),
+                                      num_active,
+                                      stream.value());
+      }
+      thrust::reduce_by_key(
+        rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+        run_ids.begin(),
+        run_ids.begin() + num_active,
+        elem_minmax.begin(),
+        cuda::make_discard_iterator(),
+        run_minmax.begin(),
+        cuda::std::equal_to<cuda::std::uint32_t>{},
+        len_minmax_combine{});
+      thrust::transform(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                        counting,
+                        counting + num_active,
+                        tied_flags.begin(),
+                        keep_active_window{cur_keys,
+                                           num_active,
+                                           run_ids.data(),
+                                           run_minmax.data(),
+                                           consumed_bytes + prefix_bytes,
+                                           polarity.element_class(true)});
+
+      // Freeze the resolved singletons: scatter each untied element's child index to its final
+      // output slot (the slot at its sorted position). They are dropped from the working set below
+      // and never revisited.
+      thrust::scatter_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                         cur_child,
+                         cur_child + num_active,
+                         cur_pos,
+                         tied_flags.begin(),
+                         d_indices_out,
+                         cuda::std::logical_not<bool>{});
+
+      // Compact the keys, child indices, and output slots down to just the still-tied elements so
+      // the next pass radixes only that remainder. The slots stay ascending because compaction
+      // preserves order. Each compaction reports the same surviving count; reading it is the one
+      // host synchronization per pass (at most MAX_RADIX_PASSES of them). A device-side predicate
+      // feeding the next launch could remove the sync if profiling shows it dominates, but the pass
+      // count is tiny so it is left simple here.
+      auto const compact = [&](auto const* d_in, auto* d_out) {
+        rmm::device_buffer d_temp_storage;
+        size_t temp_storage_bytes = 0;
+        cub::DeviceSelect::Flagged(d_temp_storage.data(),
+                                   temp_storage_bytes,
+                                   d_in,
+                                   tied_flags.data(),
+                                   d_out,
+                                   d_num_tied.data(),
+                                   num_active,
+                                   stream.value());
+        d_temp_storage = rmm::device_buffer{temp_storage_bytes, stream};
+        cub::DeviceSelect::Flagged(d_temp_storage.data(),
+                                   temp_storage_bytes,
+                                   d_in,
+                                   tied_flags.data(),
+                                   d_out,
+                                   d_num_tied.data(),
+                                   num_active,
+                                   stream.value());
+      };
+      compact(cur_keys, nxt_keys);
+      compact(cur_child, nxt_child);
+      compact(cur_pos, nxt_pos);
+      cuda::std::swap(cur_keys, nxt_keys);
+      cuda::std::swap(cur_child, nxt_child);
+      cuda::std::swap(cur_pos, nxt_pos);
+      num_active = d_num_tied.value(stream);
+      consumed_bytes += prefix_bytes;
+    }
+
+    // Resolve any runs still tied after the windows by comparison so the result matches the
+    // comparison path exactly. A surviving run agrees on the first `consumed_bytes` bytes, so the
+    // comparison skips them and orders by the remainder. The survivors are runs that did not
+    // resolve within the pass cap and the mixed-length zero-extension families the drop
+    // deliberately kept -- a string and that same string plus trailing bytes, a pure length tie no
+    // window can separate but `compare_suffix`'s length difference does; byte-identical runs were
+    // already frozen during the loop. A null run carries the null flag in `seg_null` and is left
+    // untouched -- and none reach here, since the count-first gate excludes nulls. Singletons
+    // resolved earlier were already scattered, so only the survivors remain here; when none do this
+    // is a no-op.
+    auto const tie_offset = consumed_bytes;
+    thrust::for_each(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     counting,
+                     counting + num_active,
+                     prefix_tie_breaker{cur_keys,
+                                        cur_child,
+                                        *d_input,
+                                        num_active,
+                                        tie_offset,
+                                        polarity.descending,
+                                        polarity.element_class(true)});
+
+    // Scatter the surviving child indices back to their output slots. Singletons frozen during the
+    // loop, and every untied position from the first pass, keep their order untouched.
+    thrust::scatter(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                    cur_child,
+                    cur_child + num_active,
+                    cur_pos,
+                    d_indices_out);
+  }
+
+  return sorted_indices;
+}
+
+}  // namespace detail
+}  // namespace cudf

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -14,6 +14,8 @@
 
 #include <algorithm>
 #include <limits>
+#include <random>
+#include <string>
 #include <vector>
 
 using namespace cudf::test::iterators;
@@ -183,6 +185,183 @@ TEST_F(SortListsInt, NullRows)
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), l);
 }
 
+using SortListsString = SortLists<cudf::string_view>;
+
+// E = STRING: the element type Spark `array_sort(array<string>)` lowers to. Uses the default order
+// (ascending, nulls-after). Covers nulls-last element ordering within a row and a preserved null
+// list row.
+TEST_F(SortListsString, Strings)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  // Row 0 holds a null element (at index 2) among unsorted strings; row 2 is a whole null list row.
+  std::vector<bool> const valids{true, true, false, true};
+  StrLCW input{{StrLCW{{"pear", "apple", "fig", "kiwi"}, null_at(2)},
+                StrLCW{"banana"},
+                StrLCW{"unused"},
+                StrLCW{"melon", "cherry"}},
+               valids.begin()};
+
+  // Default order ascending, nulls-after: row 0's non-null strings sort to {apple, kiwi, pear}
+  // with the null moved to the end. The null slot's placeholder value is not compared. Row 2 stays
+  // a null list row, unchanged by the sort.
+  StrLCW expected{{StrLCW{{"apple", "kiwi", "pear", "fig"}, null_at(3)},
+                   StrLCW{"banana"},
+                   StrLCW{"unused"},
+                   StrLCW{"cherry", "melon"}},
+                  valids.begin()};
+
+  auto const [sorted_lists, stable_sorted_lists] =
+    generate_sorted_lists(cudf::lists_column_view{input}, {}, {});
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// The Prefix* tests target the STRING ascending/nulls-after fast path, which orders elements by a
+// packed key of their leading bytes and then resolves prefix ties by successive byte windows and a
+// final byte comparison. Each asserts both sort_lists (the fast path) and stable_sort_lists (the
+// comparison path) match a host-built expected column, so any divergence in the fast path from the
+// comparison semantics is caught directly.
+
+// Distinct strings whose first eight bytes are identical force the prefix to tie, exercising the
+// full-string tie-break. "abcdefgh" is a proper prefix of the other two, so it sorts first.
+TEST_F(SortListsString, PrefixEqualFirstEightBytes)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"abcdefgh1", "abcdefgh0", "abcdefgh"}};
+  StrLCW expected{{"abcdefgh", "abcdefgh0", "abcdefgh1"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// A short string that is a prefix of a longer one must sort first ("aa" < "aaa"). With both under
+// eight bytes, the longer string's prefix has a non-zero byte where the shorter is zero-padded, so
+// the prefix alone already orders them.
+TEST_F(SortListsString, PrefixSubstringShorterFirst)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"aaa", "aa", "a"}};
+  StrLCW expected{{"a", "aa", "aaa"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Empty strings carry an all-zero prefix and must sort before any non-empty string. Multiple empty
+// strings tie on both prefix and full string, so their relative order is unconstrained.
+TEST_F(SortListsString, PrefixEmptyStringsFirst)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"banana", "", "apple", "", "fig"}};
+  StrLCW expected{{"", "", "apple", "banana", "fig"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Several null elements in one row must collect at the end under null_order::AFTER while the
+// non-null strings sort ascending ahead of them. The null slots' placeholder values are not
+// compared.
+TEST_F(SortListsString, PrefixMultipleNullsLast)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{StrLCW{{"pear", "apple", "fig", "kiwi", "lime"}, nulls_at({1, 3})}};
+  StrLCW expected{StrLCW{{"fig", "lime", "pear", "apple", "kiwi"}, nulls_at({3, 4})}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// A whole null list row sits next to populated rows; the sort leaves the null row untouched and
+// orders the others, exercising the fast path alongside a null row in the same column.
+TEST_F(SortListsString, PrefixAllNullListRow)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  std::vector<bool> const valids{true, false, true};
+  StrLCW input{{StrLCW{"cherry", "apple", "banana"}, StrLCW{"unused"}, StrLCW{"date", "egg"}},
+               valids.begin()};
+  StrLCW expected{{StrLCW{"apple", "banana", "cherry"}, StrLCW{"unused"}, StrLCW{"date", "egg"}},
+                  valids.begin()};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Every element of the row shares one eight-byte prefix, so the entire row is a single prefix tie
+// run resolved wholly by full-string comparison. This is the worst case for the tie-break: one run
+// spanning the whole segment.
+TEST_F(SortListsString, PrefixWholeRowShared)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"prefix__zebra", "prefix__apple", "prefix__mango", "prefix__"}};
+  StrLCW expected{{"prefix__", "prefix__apple", "prefix__mango", "prefix__zebra"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// UTF-8 multibyte strings must order by raw byte value, which is what the fast path's byte-packed
+// prefix and full-string compare both use. The two-byte (é, U+00E9 -> 0xC3 0xA9), three-byte
+// (€, U+20AC -> 0xE2 0x82 0xAC), and four-byte (U+1F600 -> 0xF0 0x9F 0x98 0x80) lead bytes order
+// after the ASCII strings and by lead-byte class among themselves (0xC3 < 0xE2 < 0xF0), so all four
+// UTF-8 sequence lengths are pinned through the packed key.
+TEST_F(SortListsString, PrefixUtf8Multibyte)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{
+    {"\xE2\x82\xAC\x75\x72\x6F", "zoo", "\xF0\x9F\x98\x80", "\xC3\xA9\x70\xC3\xA9\x65", "apple"}};
+  StrLCW expected{
+    {"apple", "zoo", "\xC3\xA9\x70\xC3\xA9\x65", "\xE2\x82\xAC\x75\x72\x6F", "\xF0\x9F\x98\x80"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Multiple rows in one column exercise the segment_id key field: each row sorts independently and
+// the per-row prefix ties (rows 0 and 3 share an eight-byte prefix within the row) resolve without
+// crossing row boundaries. An empty row (row 1) checks that dense segment-ordinal labeling skips a
+// zero-length segment without misaligning the populated rows around it.
+TEST_F(SortListsString, PrefixMultipleSegments)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{StrLCW{"commonpx_b", "commonpx_a", "commonpx_c"},
+               StrLCW{},
+               StrLCW{"melon", "apple", "cherry"},
+               StrLCW{"sharedpx2", "sharedpx0", "sharedpx1"}};
+  StrLCW expected{StrLCW{"commonpx_a", "commonpx_b", "commonpx_c"},
+                  StrLCW{},
+                  StrLCW{"apple", "cherry", "melon"},
+                  StrLCW{"sharedpx0", "sharedpx1", "sharedpx2"}};
+
+  auto const [sorted_lists, stable_sorted_lists] = generate_sorted_lists(
+    cudf::lists_column_view{input}, cudf::order::ASCENDING, cudf::null_order::AFTER);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
 namespace {
 // Sorts `input` under the given explicit (order, null_order) -- ascending / nulls-after by default
 // -- through the fast path (`sort_lists`) and the comparison path (`stable_sort_lists`), asserting
@@ -226,6 +405,533 @@ std::unique_ptr<cudf::column> as_single_row_list(std::unique_ptr<cudf::column> l
   return cudf::make_lists_column(1, offsets.release(), std::move(leaf), 0, {});
 }
 }  // namespace
+
+// Short distinct strings, each shorter than the packed key, ordered entirely by the key with no
+// tie-break. Adds multi-byte discrimination ("aaa" < "ab" turns on the second byte) beyond the
+// simpler substring case.
+TEST_F(SortListsString, PrefixShortStrings)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{{"aaa", "aa", "a", "ab", "b"}};
+  StrLCW expected{{"a", "aa", "aaa", "ab", "b"}};
+  expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+}
+
+// Shared-prefix data with a null and a duplicate: the realistic regime the shared_prefix_len
+// benchmark axis targets, where distinct strings agree on a leading run of bytes so the packed key
+// is uninformative and the tie-break does the real ordering. Row 0's strings share an eight-byte
+// "AAAAAAAA" prefix, forcing the comparison past the leading bytes, and include a null (sorts last
+// under null_order::AFTER) and a duplicate. Row 1's strings share a five-byte "food_" prefix.
+TEST_F(SortListsString, PrefixSharedPrefixWithNullAndDuplicate)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+
+  StrLCW input{
+    StrLCW{{"AAAAAAAAzebra", "AAAAAAAAapple", "AAAAAAAAmango", "unused", "AAAAAAAAapple"},
+           null_at(3)},
+    StrLCW{"food_pear", "food_kiwi", "food_pear"}};
+  StrLCW expected{
+    StrLCW{{"AAAAAAAAapple", "AAAAAAAAapple", "AAAAAAAAmango", "AAAAAAAAzebra", "unused"},
+           null_at(4)},
+    StrLCW{"food_kiwi", "food_pear", "food_pear"}};
+  expect_both_sort_paths_match(cudf::lists_column_view{input}, expected);
+}
+
+// Guards the null/0xFF distinction. A naive 0xFF..FF null sentinel would collide with a non-null
+// string whose leading bytes are all 0xFF, making the two indistinguishable to the radix and
+// leaving the non-null 0xFF strings unordered and misplaced relative to the real null under
+// null_order::AFTER. `packed_key_builder`'s dedicated is_null bit avoids that by construction: it
+// sits above every prefix bit a non-null value can set, so the null separates cleanly in the first
+// pass. The two 0xFF strings instead tie with each other -- they run 72 and 73 bytes of 0xFF, so
+// every byte window the iterative passes inspect is also all-0xFF, and they reach the comparison
+// cleanup as one run. The correct order sorts the non-nulls ascending by unsigned byte value --
+// both 0xFF strings after the ASCII strings, the shorter 0xFF string before the longer (a prefix
+// sorts first) -- with the genuine null last. Built against a host reference so the fast path's
+// divergence is caught directly.
+TEST_F(SortListsString, PrefixNullSentinelCollisionFF)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const ff72(72, '\xff');
+  std::string const ff73(73, '\xff');
+
+  // One row: two ASCII strings, two all-0xFF strings, and a genuine null (placeholder value
+  // unused).
+  std::vector<std::string> const in_strings{"apple", ff73, "mango", ff72, ""};
+  std::vector<bool> const in_valids{true, true, true, true, false};
+
+  // Host reference: non-nulls ascending by raw bytes (0xFF strings sort after ASCII; ff72 < ff73 as
+  // a prefix), then the null last under null_order::AFTER.
+  std::vector<std::string> const ex_strings{"apple", "mango", ff72, ff73, ""};
+  std::vector<bool> const ex_valids{true, true, true, true, false};
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// A single row whose non-null elements all share an 80-byte prefix -- past the 71 bytes any
+// iterative radix window reaches (see PrefixTrueHeapsortRun) -- forms one prefix tie run longer
+// than TIE_HEAPSORT_THRESHOLD, so the tie-break takes its heapsort branch, not insertion sort.
+// Exceeding STRINGS_GRAD_WARP_CAP (64) keeps the column on the prefix path. The run holds seventy
+// distinct two-digit-tail strings plus two exact duplicates (72 non-null) in a deterministic
+// shuffle, with two nulls that collect last under null_order::AFTER, so heapsort is exercised
+// alongside null placement and checked against std::sort and the comparison path.
+TEST_F(SortListsString, PrefixSharedPrefixHeapsortRun)
+{
+  std::string const prefix(80, 'A');  // 80 > 7 + 8*8 = 71, so ties survive every iterative window.
+  std::vector<std::string> non_null;
+  for (int i = 0; i < 70; ++i) {
+    non_null.push_back(prefix + std::to_string(i / 10) + std::to_string(i % 10));
+  }
+  // Two exact duplicates land among genuine distinct strings; their relative order is immaterial.
+  non_null.push_back(prefix + "05");
+  non_null.push_back(prefix + "17");
+
+  // The fast path is unstable, so the input must arrive unsorted to prove the heapsort orders it.
+  auto shuffled = non_null;
+  std::shuffle(shuffled.begin(), shuffled.end(), std::mt19937{0xC0'FFEE});
+
+  // Interleave two nulls so the row mixes the long shared-prefix run with null elements.
+  auto const null_pos_a = shuffled.size() / 3;
+  auto const null_pos_b = (shuffled.size() * 2) / 3 + 1;
+  std::vector<std::string> in_strings;
+  std::vector<bool> in_valids;
+  for (std::size_t i = 0; i <= shuffled.size(); ++i) {
+    if (i == null_pos_a || i == null_pos_b) {
+      in_strings.emplace_back("");  // Placeholder for a null element; its value is never compared.
+      in_valids.push_back(false);
+    }
+    if (i < shuffled.size()) {
+      in_strings.push_back(shuffled[i]);
+      in_valids.push_back(true);
+    }
+  }
+
+  // Host reference: non-null strings ascending by raw bytes, the two nulls last (nulls AFTER).
+  auto sorted = non_null;
+  std::sort(sorted.begin(), sorted.end());
+  std::vector<std::string> ex_strings = sorted;
+  std::vector<bool> ex_valids(sorted.size(), true);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+
+  using StrCW                     = cudf::test::strings_column_wrapper;
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Worst case for the iterative-radix tie-break: leading runs far longer than the eight-byte key,
+// so the order is decided only after several windows past the initial prefix. Row 0 mixes a
+// twenty-byte shared prefix (more than twice the eight-byte key and five times the four-byte key)
+// with distinct tails of varying length (mixed run lengths), two exact duplicates, an empty string,
+// a whole-element null, and -- crucially -- a length tie that no byte window can resolve: a string
+// and that same string plus a trailing embedded null byte, separable only by the comparison
+// cleanup's shorter-is-less rule. Row 1 is an outlier of thousands of strings sharing a twenty-four
+// byte prefix with distinct four-digit tails, exercising the pass cap and the parallel re-sort that
+// replaces the serial straggler. The host reference sorts each row's non-null strings by
+// std::string ordering (raw-byte lexicographic with the same length tie-break) and appends the
+// nulls last, and the assertion checks the fast path against the comparison path.
+TEST_F(SortListsString, PrefixIterativeDeepLongSharedPrefix)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const prefix0(20, 'A');  // Twenty shared bytes: > 2x the 8-byte key, 5x the 4-byte.
+  std::vector<std::string> row0_non_null{
+    prefix0 + "zebra",
+    prefix0 + "ant",  // Shorter tail than its neighbors -> mixed run lengths within the shared run.
+    prefix0 + "mango",
+    prefix0 + "ant",                 // Exact duplicate of an earlier element.
+    prefix0,                         // The shared prefix with no tail (the prefix-of element).
+    prefix0 + std::string(1, '\0'),  // Same bytes as `prefix0` plus a trailing embedded null byte;
+                                     // a pure length tie that no byte window can separate.
+    prefix0 + "mango",               // Second exact duplicate.
+    ""};                             // Empty string: all-zero key, must sort first in the row.
+
+  // Row 1: a large outlier sharing a long prefix, with distinct tails forcing many tied passes.
+  std::string const prefix1(24, 'Q');  // Twenty-four shared bytes -> three windows past an 8B key.
+  std::vector<std::string> row1;
+  row1.reserve(5'000);
+  for (int i = 0; i < 5'000; ++i) {
+    auto tail = std::to_string(i);
+    tail.insert(tail.begin(), 4 - tail.size(), '0');  // Zero-pad to four digits for a fixed width.
+    row1.push_back(prefix1 + tail);
+  }
+  // Arrive unsorted so the sort must do real work; a fixed shuffle keeps the test deterministic.
+  std::shuffle(row1.begin(), row1.end(), std::mt19937{0x5EED});
+
+  // Assemble the leaf strings and validity: row 0 (with one null appended), then row 1 (no nulls).
+  std::vector<std::string> in_strings;
+  std::vector<bool> in_valids;
+  for (auto const& s : row0_non_null) {
+    in_strings.push_back(s);
+    in_valids.push_back(true);
+  }
+  in_strings.emplace_back("");  // Placeholder for a null element; its value is never compared.
+  in_valids.push_back(false);
+  auto const row0_len = static_cast<cudf::size_type>(in_strings.size());
+  for (auto const& s : row1) {
+    in_strings.push_back(s);
+    in_valids.push_back(true);
+  }
+  auto const total_len = static_cast<cudf::size_type>(in_strings.size());
+
+  // Host reference: each row's non-null strings ascending by std::string (raw-byte order with the
+  // same length tie-break), then the row 0 null last.
+  auto row0_sorted = row0_non_null;
+  std::sort(row0_sorted.begin(), row0_sorted.end());
+  auto row1_sorted = row1;
+  std::sort(row1_sorted.begin(), row1_sorted.end());
+
+  std::vector<std::string> ex_strings;
+  std::vector<bool> ex_valids;
+  for (auto const& s : row0_sorted) {
+    ex_strings.push_back(s);
+    ex_valids.push_back(true);
+  }
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+  for (auto const& s : row1_sorted) {
+    ex_strings.push_back(s);
+    ex_valids.push_back(true);
+  }
+
+  auto const make_two_row_list = [&](std::vector<std::string> const& strs,
+                                     std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, row0_len, total_len};
+    return cudf::make_lists_column(2, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_two_row_list(in_strings, in_valids);
+  auto const expected = make_two_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Exercises the length-uniform exhausted-run drop directly: a run of many byte-identical strings
+// longer than the packed key enters the window loop as one tie run, and once the windows cover
+// their length the run is length-uniform and exhausted, so it is frozen in one step instead of
+// being dragged through the pass cap and the comparison cleanup. A distinct-tailed string (a
+// singleton) and a shorter proper prefix round out the row. The frozen order must still match the
+// comparison path.
+TEST_F(SortListsString, PrefixExhaustedIdenticalRunDropped)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+  std::vector<std::string> in;
+  for (int i = 0; i < 40; ++i) {
+    in.emplace_back("abcdefghijkl");  // Forty copies of one 12-byte string: a byte-identical run.
+  }
+  in.emplace_back("abcdefghijkZ");  // Shares the twelve-byte prefix but the last byte: a singleton.
+  in.emplace_back("abcdefgh");      // Shorter proper prefix: its own run, sorts first.
+
+  auto expected = in;
+  std::sort(expected.begin(), expected.end());
+
+  auto const input        = as_single_row_list(StrCW{in.begin(), in.end()}.release());
+  auto const expected_col = as_single_row_list(StrCW{expected.begin(), expected.end()}.release());
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected_col->view());
+}
+
+// Regression guard for the drop's length-uniformity condition. A string and its zero-extension (the
+// same bytes plus a trailing embedded null) collide in every byte window and in the packed key --
+// only their length differs -- so the stable radix keeps whichever arrived first. Here the LONGER
+// one is placed before the shorter, so the stable order is the WRONG lexicographic order (a proper
+// prefix sorts first). An exhaustion-only drop would freeze that wrong order; the length-uniform
+// guard keeps this mixed-length run for the comparison cleanup, which orders shorter-first. The
+// shared bytes exceed the eight-byte window and the packed key, so the run exhausts well inside the
+// loop where a naive drop would fire.
+TEST_F(SortListsString, PrefixZeroExtensionLongerFirstNotDropped)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+  std::string const base(20, 'A');   // Twenty shared bytes.
+  std::string const shorter = base;  // Length twenty.
+  std::string const longer =
+    base + std::string(1, '\0');  // Length twenty-one: `base` + a NUL byte.
+
+  // Longer first, then shorter: stable radix keeps this order, so only a length-aware step can fix
+  // it. Two strings diverging at the twenty-first byte keep the run non-trivial and resolve as
+  // singletons.
+  std::vector<std::string> in{longer, shorter, base + "B", base + "C"};
+  auto expected = in;
+  std::sort(expected.begin(), expected.end());  // shorter < longer < base+"B" < base+"C".
+
+  auto const input        = as_single_row_list(StrCW{in.begin(), in.end()}.release());
+  auto const expected_col = as_single_row_list(StrCW{expected.begin(), expected.end()}.release());
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected_col->view());
+}
+
+// Targets the singleton-compaction path: a column mixing many rows whose elements are all distinct
+// in their first bytes (resolved by the first pass, so they must be left untouched by the iterative
+// windows) with one deep-shared-prefix row that drives several windows. The compaction must extract
+// only the deep row's still-tied elements, re-sort just those, and scatter them back without
+// disturbing the already-resolved rows. Built as many short distinct-prefix rows surrounding one
+// giant row of strings sharing a long prefix; the host reference sorts each row independently so a
+// stray reorder of any resolved row -- or a misplaced scatter -- is caught against the comparison
+// path.
+TEST_F(SortListsString, PrefixCompactionMixedSingletonAndDeepRows)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::vector<std::vector<std::string>> rows;
+  // Twelve "easy" rows: every element differs within the first byte, so each is its own run after
+  // the first pass and the iterative passes must not touch them.
+  for (int r = 0; r < 12; ++r) {
+    rows.push_back({std::string(1, static_cast<char>('a' + r)) + "_zzz",
+                    std::string(1, static_cast<char>('A' + r)) + "_aaa",
+                    std::string(1, static_cast<char>('0' + r)) + "_mmm"});
+  }
+  // One "deep" row: 1500 strings sharing a thirty-two byte prefix (four windows past an 8-byte
+  // key), distinct four-digit tails, shuffled. This is the only row the compaction should re-sort.
+  std::string const deep_prefix(32, 'D');
+  std::vector<std::string> deep;
+  deep.reserve(1'500);
+  for (int i = 0; i < 1'500; ++i) {
+    auto tail = std::to_string(i);
+    tail.insert(tail.begin(), 4 - tail.size(), '0');
+    deep.push_back(deep_prefix + tail);
+  }
+  std::shuffle(deep.begin(), deep.end(), std::mt19937{0xD00D});
+  // Place the deep row in the middle so resolved rows sit on both sides of the compacted block.
+  rows.insert(rows.begin() + 6, deep);
+
+  // Flatten to leaf strings + per-row offsets; build the host-sorted expected the same way.
+  std::vector<std::string> in_strings;
+  std::vector<std::string> ex_strings;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const& row : rows) {
+    for (auto const& s : row) {
+      in_strings.push_back(s);
+    }
+    auto sorted = row;
+    std::sort(sorted.begin(), sorted.end());
+    for (auto const& s : sorted) {
+      ex_strings.push_back(s);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_strings.size()));
+  }
+
+  auto const num_rows  = static_cast<cudf::size_type>(rows.size());
+  auto const make_list = [&](std::vector<std::string> const& strs) {
+    StrCW leaf{strs.begin(), strs.end()};
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_list(in_strings);
+  auto const expected = make_list(ex_strings);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Guards the packed-key tie-break offset. The single-uint64 first key holds only P prefix bits,
+// where P follows the segment-label width S = bit_width(num_segments). The labels are dense
+// segment ordinals, so a single list row is one segment: S = bit_width(1) = 1, and with nulls
+// present P = 64 - 1 - 1 = 62, which is NOT a byte multiple. The key thus proves only
+// floor(62/8) = 7 whole leading bytes equal plus the top six bits of byte 7 -- never byte 7's low
+// two bits. The two probe strings "AAAAAA\0\x01" and "AAAAAA\0\x02" agree on their first seven
+// bytes and on byte 7's top six bits (both 0x01 and 0x02 are below 4, so byte 7 >> 2 is 0 for
+// each), so they tie on the packed key; they differ only in byte 7's low two bits. A correct
+// tie-break resumes its byte windows at byte 7 and separates them (\x01 < \x02); a stale offset
+// that skipped a fixed eight bytes would compare past both eight-byte strings, leave them tied,
+// and order them arbitrarily. The row holds 200 elements -- the probe pair, two nulls, and
+// distinct "B"-prefixed singletons -- but the count no longer drives S (one row fixes
+// num_segments = 1); it only keeps the probe pair its own two-element prefix-tie run amid many
+// first-pass singletons. Built against a host std::sort reference (raw-byte order, embedded nulls
+// and all) so any offset drift is caught against the comparison path.
+TEST_F(SortListsString, PrefixPackedKeyPartialByteTieOffset)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const probe_lo = std::string("AAAAAA") + '\0' + '\x01';  // 8 bytes, byte 7 = 0x01.
+  std::string const probe_hi = std::string("AAAAAA") + '\0' + '\x02';  // 8 bytes, byte 7 = 0x02.
+
+  // Distinct "B"-prefixed fillers: each differs within its first bytes, so they resolve in the
+  // first pass and never merge into the probe pair's "A"-prefixed run. Two nulls force the layout's
+  // null bit (P = 62, not 63) and must collect last under null_order::AFTER.
+  std::vector<std::string> in_strings;
+  std::vector<bool> in_valids;
+  in_strings.push_back(probe_hi);  // Arrive out of order so the tie-break must reorder the pair.
+  in_valids.push_back(true);
+  in_strings.push_back(probe_lo);
+  in_valids.push_back(true);
+  in_strings.emplace_back("");  // Null placeholder; its value is never compared.
+  in_valids.push_back(false);
+  for (int i = 0; in_strings.size() < 199; ++i) {
+    auto tail = std::to_string(i);
+    tail.insert(tail.begin(), 4 - tail.size(), '0');
+    in_strings.push_back("B" + tail);
+    in_valids.push_back(true);
+  }
+  in_strings.emplace_back("");  // Second null placeholder.
+  in_valids.push_back(false);
+  // 200 elements total, but all in one list row => num_segments = 1 => S = bit_width(1) = 1, and
+  // with nulls P = 62, floor(P/8) = 7 (a non-byte-multiple P, the offset this test probes).
+  auto const num_elements = static_cast<cudf::size_type>(in_strings.size());
+
+  // Host reference: non-null strings ascending by raw bytes (std::string compares unsigned bytes
+  // and respects the embedded null), then the two nulls last.
+  std::vector<std::string> non_null;
+  for (std::size_t i = 0; i < in_strings.size(); ++i) {
+    if (in_valids[i]) { non_null.push_back(in_strings[i]); }
+  }
+  std::sort(non_null.begin(), non_null.end());
+  std::vector<std::string> ex_strings = non_null;
+  std::vector<bool> ex_valids(non_null.size(), true);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+  ex_strings.emplace_back("");
+  ex_valids.push_back(false);
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  // One list row fixes num_segments = 1 (so S = 1, P = 62); pin the element count only to keep the
+  // probe pair amid a bulk of first-pass singletons rather than alone.
+  EXPECT_EQ(num_elements, 200);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// One row mixes three adjacent null elements with genuine non-null tie groups: an eight-byte
+// "AAAAAAAA" shared-prefix trio with distinct tails (a first-pass prefix tie the windows resolve)
+// and a duplicated "apple" (an exact tie). Under null_order::AFTER the nulls collect last while
+// the non-nulls sort ascending, verifying that excluding nulls from the tie-break set (they are
+// position-final after the first pass, never counted tied) keeps their placement correct. Were a
+// null instead dragged through the windows, this would still be correct but slower; the check here
+// guards the exclusion against ever misplacing a null.
+TEST_F(SortListsString, PrefixNullRunsNeverTied)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::vector<std::string> const in_strings{
+    "AAAAAAAA3", "", "", "", "AAAAAAAA1", "AAAAAAAA2", "zebra", "apple", "apple"};
+  std::vector<bool> const in_valids{true, false, false, false, true, true, true, true, true};
+
+  // Non-nulls ascending by raw bytes ('A' 0x41 < 'a' 0x61 < 'z' 0x7A), then the three nulls last.
+  std::vector<std::string> const ex_strings{
+    "AAAAAAAA1", "AAAAAAAA2", "AAAAAAAA3", "apple", "apple", "zebra", "", "", ""};
+  std::vector<bool> const ex_valids{true, true, true, true, true, true, false, false, false};
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs,
+                                       std::vector<bool> const& valids) {
+    StrCW leaf{strs.begin(), strs.end(), valids.begin()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(in_strings, in_valids);
+  auto const expected = make_single_row_list(ex_strings, ex_valids);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// One row is nothing but ten copies of a single non-empty string -- a whole segment collapsing to
+// one all-duplicate tie run (equal keys and equal bytes, so their order is immaterial) -- beside
+// ordinary rows. A known suite gap: exercises the tie-break on a segment-spanning run of exact
+// duplicates, which must leave every row correctly ordered.
+TEST_F(SortListsString, PrefixWholeSegmentDuplicate)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::vector<std::string> const dup_row(10, "duplicate");
+  std::vector<std::vector<std::string>> const rows{
+    {"cherry", "apple", "banana"}, dup_row, {"melon", "date", "fig"}};
+
+  std::vector<std::string> in_strings;
+  std::vector<std::string> ex_strings;
+  std::vector<cudf::size_type> offsets{0};
+  for (auto const& row : rows) {
+    for (auto const& s : row) {
+      in_strings.push_back(s);
+    }
+    auto sorted = row;
+    std::sort(sorted.begin(), sorted.end());
+    for (auto const& s : sorted) {
+      ex_strings.push_back(s);
+    }
+    offsets.push_back(static_cast<cudf::size_type>(in_strings.size()));
+  }
+
+  auto const num_rows  = static_cast<cudf::size_type>(rows.size());
+  auto const make_list = [&](std::vector<std::string> const& strs) {
+    StrCW leaf{strs.begin(), strs.end()};
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+    return cudf::make_lists_column(num_rows, off.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_list(in_strings);
+  auto const expected = make_list(ex_strings);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+// Forces the comparison cleanup's heapsort branch, which no other test reaches: >= 40 elements in
+// ONE row share a prefix long enough that every iterative window sees only shared bytes, so the
+// whole run survives to the cleanup as one run >= TIE_HEAPSORT_THRESHOLD (32) and is sorted by
+// heapsort rather than insertion. Layout arithmetic for this test: one list row => num_segments = 1
+// => S = bit_width(1) = 1; no nulls => P = 64 - 1 = 63, so the first pass proves floor(63/8) = 7
+// whole bytes. The MAX_RADIX_PASSES (8) windows then consume 8 * prefix_bytes (8) = 64 more, so the
+// last window ends at byte 7 + 64 = 71. An 80-byte shared prefix exceeds 71, so no window can
+// separate any element and the distinct two-digit tails (at byte 80, beyond every window) are
+// resolved only by the cleanup. Two exact duplicates check the heapsort's handling of equal keys.
+TEST_F(SortListsString, PrefixTrueHeapsortRun)
+{
+  using StrCW = cudf::test::strings_column_wrapper;
+
+  std::string const prefix(80, 'Z');  // 80 > 7 + 8*8 = 71, so ties survive every iterative window.
+  std::vector<std::string> non_null;
+  // Exceeding STRINGS_GRAD_WARP_CAP (> 64 elements) sends the column down the prefix path
+  // (not the graduated-warp path), so the tie run genuinely reaches TIE_HEAPSORT_THRESHOLD.
+  for (int i = 0; i < 70; ++i) {
+    non_null.push_back(prefix + std::to_string(i / 10) + std::to_string(i % 10));
+  }
+  // Two exact duplicates land among the distinct strings; their relative order is immaterial.
+  non_null.push_back(prefix + "05");
+  non_null.push_back(prefix + "17");
+
+  // The fast path is unstable, so the input must arrive unsorted to prove the heapsort orders it.
+  auto shuffled = non_null;
+  std::shuffle(shuffled.begin(), shuffled.end(), std::mt19937{0x8EA7});
+
+  // Host reference: ascending by raw bytes; all share the prefix, so ordered by the two-digit tail.
+  auto sorted = non_null;
+  std::sort(sorted.begin(), sorted.end());
+
+  auto const make_single_row_list = [](std::vector<std::string> const& strs) {
+    StrCW leaf{strs.begin(), strs.end()};
+    auto const n = static_cast<cudf::size_type>(strs.size());
+    cudf::test::fixed_width_column_wrapper<cudf::size_type> offsets{0, n};
+    return cudf::make_lists_column(1, offsets.release(), leaf.release(), 0, {});
+  };
+
+  auto const input    = make_single_row_list(shuffled);
+  auto const expected = make_single_row_list(sorted);
+  expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
 
 // Sign-flip correctness at the signed-integer boundaries: INT_MIN must sort first and INT_MAX last
 // among the non-nulls, with every negative ahead of every non-negative, for both rep widths. The
@@ -536,6 +1242,23 @@ TEST_F(SortListsInt, SlicedWithNulls)
     cudf::lists_column_view{sliced_list}, cudf::order::ASCENDING, cudf::null_order::AFTER);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(sorted_lists->view(), expected);
   CUDF_TEST_EXPECT_COLUMNS_EQUAL(stable_sorted_lists->view(), expected);
+}
+
+// Nonzero column offset for the strings prefix path: slicing off row 0 gives the surviving rows'
+// leaf strings column a genuine nonzero offset, which the packed-key builder, the window tie-break,
+// and the null handling must all honor. Mirrors SlicedWithNulls (the tiered engine's offset + null
+// combo) for the string engine.
+TEST_F(SortListsString, PrefixSlicedWithNulls)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  StrLCW l{StrLCW{"zz", "aa"},
+           StrLCW{{"banana", "apple", "x", "cherry"}, null_at(2)},
+           StrLCW{"b", "a"},
+           StrLCW{"x"}};
+  auto const sliced_list = cudf::slice(l, {1, 4})[0];  // drops row 0 -> nonzero child offset
+  StrLCW expected{
+    StrLCW{{"apple", "banana", "cherry", "x"}, null_at(3)}, StrLCW{"a", "b"}, StrLCW{"x"}};
+  expect_both_sort_paths_match(cudf::lists_column_view{sliced_list}, expected);
 }
 
 // The tiered kernel's warp tier in isolation: three single-row columns within the warp cap (64) and

--- a/cpp/tests/sort/segmented_sort_tests.cpp
+++ b/cpp/tests/sort/segmented_sort_tests.cpp
@@ -430,6 +430,21 @@ TEST_F(SegmentedSortInt, FastPathPartialOffsetsPackedRadix)
   CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
 }
 
+// Partial-coverage offsets {3, 7} on a STRING column route to the STRING prefix fast path when the
+// guard is absent; with the guard they take the comparison path, which sorts only [3, 7).
+TEST_F(SegmentedSortInt, FastPathPartialOffsetsStrings)
+{
+  cudf::test::strings_column_wrapper col{
+    "a0", "a1", "a2", "banana", "apple", "cherry", "date", "z7", "z8", "z9"};
+  cudf::test::strings_column_wrapper expected{
+    "a0", "a1", "a2", "apple", "banana", "cherry", "date", "z7", "z8", "z9"};
+  column_wrapper<int> segments{{3, 7}};
+  auto const input = cudf::table_view{{col}};
+  auto result      = cudf::segmented_sort_by_key(
+    input, input, segments, {cudf::order::ASCENDING}, {cudf::null_order::AFTER});
+  CUDF_TEST_EXPECT_TABLES_EQUAL(result->view(), cudf::table_view{{expected}});
+}
+
 // Single-index offsets (num_segments == 0) sort no values -- the documented contract. The guard
 // requires at least two offsets, so these fall through to the comparison/CUB path (which treats
 // zero segments as identity) rather than a fast path whose zero-width segment field would shift a


### PR DESCRIPTION
`cudf::lists::sort_lists` on a `LIST<STRING>` column computes its sort order through the comparison fallback, whose lexicographic row comparator bottoms out in an O(len) byte-by-byte `string_view::compare`, the dominant cost for the ascending, nulls-after case that the fixed-width fast path cannot serve.

Add a strings prefix-radix engine, `fast_segmented_sorted_order_strings_prefix` in `segmented_sort_strings.cu` and declared in `segmented_sort_fast.cuh`. It packs the leading bytes of each row into a fixed-width key (`packed_key_builder` and `pack_window`), radix-sorts the indices by segment and packed key, then iteratively deepens the key window over equal-prefix runs and tie-breaks the residual with a bounded `string_view` compare. A null class bit folds validity into the key ordering, so a null-bearing column sorts through the same path with no separate null pass. `segmented_sorted_order_common` in `segmented_sort_impl.cuh` routes an ascending, nulls-after `LIST<STRING>` order through this engine; the remaining polarities stay on the comparison fallback until a later change widens the gate.

Across the impacted ascending, nulls-after cells the new path sorts geomean 2.46x faster (1.38x to 4.55x, every impacted cell faster) while the other polarities stay unchanged, and no cell regresses beyond benchmark noise. Tests pin the packed-key construction, window deepening, tie-break, null handling, and slicing, and cross-check the fast path against the stable comparison sort.

---

**Stacked series — part 5/7, decomposing rapidsai/cudf#23101 into reviewable steps.** Stacked on #78 (base branch `improve-list-sort-04-decimal128`).

**compute-sanitizer:** memcheck + racecheck (`--rmm-mode=cuda`) over the `LIST<STRING>` sort suites — **0 errors, 0 hazards**.
