### PR TITLE
Add graduated-warp string fast path for segmented sort (6/7)

### DIFF
--- a/cpp/benchmarks/sort/sort_list_of_strings.cpp
+++ b/cpp/benchmarks/sort/sort_list_of_strings.cpp
@@ -110,12 +110,13 @@ static std::unique_ptr<cudf::column> apply_shared_prefix(cudf::column_view const
 }
 
 // The list generator forces its final offset to the child size ("always include all elements"), so
-// the last row absorbs every leftover element -- an artifact row often far above `max_list_size`,
-// handing the sweep a shape no axis value asked for. Trimming that one row back to `max_list_size`
-// restores the axis's declared [0, max_list_size] regime; it runs outside the timed region.
-// Returns nullptr when the generated last row already fits, so the caller keeps the original
-// column. The generator purges nonempty nulls, so an oversized last row is never a null row and
-// the trim cannot create a nonempty null.
+// the last row absorbs every leftover element -- an artifact row often far above `max_list_size`
+// that would disqualify the whole column from the graduated-warp path (its gate requires every
+// segment within the 64-element warp tile) and silently demote it to the prefix path. Trimming that
+// one row back to `max_list_size` restores the axis's declared [0, max_list_size] regime; it runs
+// outside the timed region. Returns nullptr when the generated last row already fits, so the caller
+// keeps the original column. The generator purges nonempty nulls, so an oversized last row is never
+// a null row and the trim cannot create a nonempty null.
 static std::unique_ptr<cudf::column> trim_forced_last_row(cudf::column_view const& list_col,
                                                           cudf::size_type max_list_size,
                                                           rmm::cuda_stream_view stream)
@@ -234,7 +235,9 @@ static void bench_sort_list_of_strings(nvbench::state& state)
   state.set_cuda_stream(nvbench::make_cuda_stream_view(stream.value()));
 
   // Trim the generator's forced-last-row artifact (untimed data setup) so the data matches the
-  // declared [0, max_list_size] regime. See `trim_forced_last_row`.
+  // declared [0, max_list_size] regime; otherwise that one oversized row disqualifies the whole
+  // column from the graduated-warp path and silently demotes it to the prefix path. See
+  // `trim_forced_last_row`.
   auto const trimmed  = trim_forced_last_row(table->view().column(0), max_list_size, stream);
   auto const base_col = trimmed ? trimmed->view() : table->view().column(0);
 

--- a/cpp/src/sort/segmented_sort_fast.cuh
+++ b/cpp/src/sort/segmented_sort_fast.cuh
@@ -212,5 +212,37 @@ fixed_width_sort_path choose_fixed_width_sort_path(column_view const& key,
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr);
 
+/**
+ * @brief Whether every segment fits the graduated path's largest warp tile
+ * (`STRINGS_GRAD_WARP_CAP`)
+ *
+ * One device count over the segment sizes plus its host synchronization, mirroring
+ * `decimal128_cub_segment_shape_ok`; the caller runs the cheap scalar gate checks first so this
+ * synchronizing probe is paid only for an otherwise-qualifying STRING column.
+ */
+bool strings_grad_all_segments_fit(column_view const& segment_offsets,
+                                   rmm::cuda_stream_view stream);
+
+/**
+ * @brief Segmented sorted-order for a STRING column via graduated in-warp sorts
+ *
+ * One virtual warp sorts each segment with `cub::WarpMergeSort` under a string comparator; the warp
+ * width follows the segment-size band (W8 for sizes <= 16, W16 for 17-32, W32 for 33-64, two items
+ * per lane, except the (0,8] slice at one), so a tiny segment never occupies a full warp. The
+ * bottom bands use the 8-byte comparator key and the upper bands the 16-byte prekey. Every band
+ * launches over the full segment list and self-filters to its size slice; the bands partition [1,
+ * 64], so every output slot is written exactly once (an empty segment has none). The caller
+ * guarantees every segment holds at most `STRINGS_GRAD_WARP_CAP` elements
+ * (`strings_grad_all_segments_fit`) and offsets spanning all rows. `polarity` folds the requested
+ * order and null placement into the keys, matching `fast_segmented_sorted_order_strings_prefix`,
+ * whose output contract this shares: indices mapping the column to its segmented sorted order.
+ */
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_grad(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr);
+
 }  // namespace detail
 }  // namespace cudf

--- a/cpp/src/sort/segmented_sort_impl.cuh
+++ b/cpp/src/sort/segmented_sort_impl.cuh
@@ -350,6 +350,13 @@ std::unique_ptr<column> segmented_sorted_order_common(
         column_order.front() == order::ASCENDING and null_precedence.size() == 1 and
         null_precedence.front() == null_order::AFTER and
         fast_path_offsets_cover_all_rows(segment_offsets, keys.num_rows(), stream)) {
+      // When every segment fits the largest warp tile, the graduated in-warp sort beats the global
+      // prefix-radix machine; an oversized segment falls through to the prefix path. As with the
+      // scalar checks above, this synchronizing size probe runs only after they pass.
+      if (strings_grad_all_segments_fit(segment_offsets, stream)) {
+        return fast_segmented_sorted_order_strings_grad(
+          keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
+      }
       return fast_segmented_sorted_order_strings_prefix(
         keys.column(0), segment_offsets, sort_polarity{}, stream, mr);
     }

--- a/cpp/src/sort/segmented_sort_strings.cu
+++ b/cpp/src/sort/segmented_sort_strings.cu
@@ -5,11 +5,13 @@
 
 #include "segmented_sort_fast.cuh"
 #include "segmented_sort_keys.cuh"
+#include "segmented_sort_warp_kernel.cuh"
 
 #include <cudf/column/column_device_view.cuh>
 #include <cudf/column/column_factories.hpp>
 #include <cudf/detail/device_scalar.hpp>
 #include <cudf/detail/labeling/label_segments.cuh>
+#include <cudf/detail/utilities/grid_1d.cuh>
 #include <cudf/strings/string_view.cuh>
 #include <cudf/utilities/error.hpp>
 #include <cudf/utilities/memory_resource.hpp>
@@ -555,6 +557,163 @@ struct prefix_tie_breaker {
   }
 };
 
+// ==========================================================================================
+// Graduated-warp per-segment sort for a single STRING key column.
+//
+// When every segment fits the largest warp tile (`STRINGS_GRAD_WARP_CAP`), sorting each segment in
+// a virtual warp with `cub::WarpMergeSort` beats the global multi-pass prefix-radix machine. The
+// warp width graduates with the segment-size band (W8 for sizes <= 16, W16 for 17-32, W32 for
+// 33-64), so a tiny segment never occupies a full warp. The key style is mixed per band: the 8-byte
+// comparator key drives the bottom bands, where the 16-byte prekey's merge-exchange volume
+// dominates over mostly-pad tiles, and the prekey drives W16/W32, where its packed prefix window
+// amortizes. The (0,8] slice sorts at one item per lane (an 8-slot tile), halving the pad traffic
+// the two-item shape pays at the smallest sizes. The requested (order, null_order) rides the same
+// `sort_polarity` the prefix path uses; a column with any segment above the cap falls through to
+// the prefix path.
+// ==========================================================================================
+
+/// Largest segment size the graduated-warp string path admits: the W32 x 2 register tile.
+constexpr size_type STRINGS_GRAD_WARP_CAP = 64;
+
+/**
+ * @brief Ordering key for the comparator-key bands: the element's global index plus its class
+ *
+ * The comparator reads the string bytes through `gidx`, so the key itself stays eight bytes. `cls`
+ * is a `tiered_element_class` whose ordinal comes from `polarity.element_class`, so nulls collect
+ * on the requested side of a segment's valid elements and the pad slots past a segment's real
+ * elements settle beyond them -- pad must rank strictly above either class for the same reason the
+ * fixed-width tiers require it. `gidx` is dereferenced only for the valid class, so a null or pad
+ * key never reads string data.
+ */
+struct strings_grad_cmp_key {
+  size_type gidx;
+  cuda::std::uint32_t cls;
+};
+static_assert(sizeof(strings_grad_cmp_key) == 8, "strings_grad_cmp_key must stay eight bytes");
+
+/// Builds the comparator key for one element: its global index and polarity-resolved class.
+struct strings_grad_cmp_key_builder {
+  column_device_view d_strings;
+  bool has_nulls;
+  sort_polarity polarity;
+  __device__ strings_grad_cmp_key operator()(size_type idx) const
+  {
+    return strings_grad_cmp_key{idx, polarity.element_class(has_nulls && d_strings.is_null(idx))};
+  }
+};
+
+/**
+ * @brief Strict-weak less for the comparator key: class first, then the full byte comparison
+ *
+ * Two keys in the same non-valid class (both null or both pad) compare equivalent -- the path is
+ * unstable, their order is immaterial, and their bytes are never read. Two valid keys order by
+ * `string_view::compare`, the unsigned-byte-then-shorter-first ordering the shipped prefix path
+ * reproduces. The valid class ordinal follows the polarity (`element_class(false)` is 1
+ * nulls-first, 0 otherwise), so a hardcoded constant would misfire under nulls-first; a descending
+ * sort inverts the comparison's sign, reversing both byte order and the length tie-break as
+ * `prefix_tie_breaker::index_less` does.
+ */
+struct strings_grad_cmp_less {
+  column_device_view d_strings;
+  sort_polarity polarity;
+  __device__ bool operator()(strings_grad_cmp_key const& a, strings_grad_cmp_key const& b) const
+  {
+    if (a.cls != b.cls) { return a.cls < b.cls; }
+    if (a.cls != polarity.element_class(false)) { return false; }
+    auto const cmp =
+      d_strings.element<string_view>(a.gidx).compare(d_strings.element<string_view>(b.gidx));
+    return polarity.descending ? cmp > 0 : cmp < 0;
+  }
+};
+
+/**
+ * @brief Ordering key for the prekey bands: a packed leading-byte prefix over the index
+ *
+ * `prefix` is the element's first eight bytes packed big-endian with a zero-filled tail
+ * (`pack_window` at offset zero), so an unsigned compare reproduces unsigned-byte order over the
+ * window under the shipped shorter-is-less zero-fill convention; a descending sort complements the
+ * window at build time so that order reverses. A prefix tie leaves only two cases -- both strings
+ * genuinely share their first eight bytes, or a shorter string's zero-fill collided with the longer
+ * one's real zero bytes (a zero-extension family such as `S` vs `S + "\0"`) -- and `compare_suffix`
+ * from byte eight orders both exactly: its byte walk covers the first case and its full-length
+ * difference the second, shorter-first.
+ */
+struct strings_grad_prekey {
+  cuda::std::uint64_t prefix;
+  size_type gidx;
+  cuda::std::uint32_t cls;
+};
+static_assert(sizeof(strings_grad_prekey) == 16 and alignof(strings_grad_prekey) == 8,
+              "strings_grad_prekey must stay sixteen bytes with eight-byte alignment");
+
+/// Builds the prekey: packed eight-byte big-endian prefix (complemented when descending), global
+/// index, polarity-resolved class. A null carries a zero prefix and is never inspected past the
+/// class compare.
+struct strings_grad_prekey_builder {
+  column_device_view d_strings;
+  bool has_nulls;
+  sort_polarity polarity;
+  __device__ strings_grad_prekey operator()(size_type idx) const
+  {
+    if (has_nulls && d_strings.is_null(idx)) {
+      return strings_grad_prekey{0, idx, polarity.element_class(true)};
+    }
+    return strings_grad_prekey{
+      pack_window(d_strings.element<string_view>(idx), 0) ^ polarity.value_mask64(),
+      idx,
+      polarity.element_class(false)};
+  }
+};
+
+/**
+ * @brief Strict-weak less for the prekey: class, then packed prefix, bytes only on a tie
+ *
+ * The packed prefix resolves most pairs in registers; it was complemented at build time under a
+ * descending sort, so a plain unsigned compare of it is correct for both directions. The byte
+ * comparison runs only when two valid keys tie on the prefix, starting at `prefix_bytes` since the
+ * tie proves the window equal, and a descending sort inverts its sign as
+ * `prefix_tie_breaker::index_less` does. The valid class follows the polarity, as in the comparator
+ * key.
+ */
+struct strings_grad_prekey_less {
+  column_device_view d_strings;
+  sort_polarity polarity;
+  __device__ bool operator()(strings_grad_prekey const& a, strings_grad_prekey const& b) const
+  {
+    if (a.cls != b.cls) { return a.cls < b.cls; }
+    if (a.cls != polarity.element_class(false)) { return false; }
+    if (a.prefix != b.prefix) { return a.prefix < b.prefix; }
+    auto const cmp = compare_suffix(d_strings.element<string_view>(a.gidx),
+                                    d_strings.element<string_view>(b.gidx),
+                                    size_type{prefix_bytes});
+    return polarity.descending ? cmp > 0 : cmp < 0;
+  }
+};
+
+/// Launches one graduated string band: virtual warps of `W` lanes sort the segments whose size is
+/// in
+/// `(band_lo, band_hi]` with `cub::WarpMergeSort`, self-filtering over the full segment list
+/// exactly as the fixed-width warp bands do.
+template <int W, int IPT, typename KeyT, typename KeyBuilder, typename CompareOp>
+void launch_strings_grad_band(KeyBuilder const& build_key,
+                              CompareOp const& compare_op,
+                              KeyT const pad_key,
+                              size_type const* d_offsets,
+                              size_type const* d_seg_list,
+                              size_type num_segments,
+                              size_type band_lo,
+                              size_type band_hi,
+                              size_type* d_out,
+                              rmm::cuda_stream_view stream)
+{
+  auto const grid =
+    cudf::detail::grid_1d(static_cast<thread_index_type>(num_segments) * W, TIERED_BLOCK_THREADS);
+  tiered_warp_band_kernel<KeyT, KeyBuilder, W, IPT, TIERED_BLOCK_THREADS, CompareOp>
+    <<<grid.num_blocks, grid.num_threads_per_block, 0, stream.value()>>>(
+      d_offsets, d_seg_list, num_segments, band_lo, band_hi, build_key, d_out, compare_op, pad_key);
+  CUDF_CHECK_CUDA(stream.value());
+}
+
 }  // namespace
 
 [[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_prefix(
@@ -1074,6 +1233,74 @@ struct prefix_tie_breaker {
                     d_indices_out);
   }
 
+  return sorted_indices;
+}
+
+bool strings_grad_all_segments_fit(column_view const& segment_offsets, rmm::cuda_stream_view stream)
+{
+  auto const num_segments = segment_offsets.size() - 1;
+  auto const d_offsets    = segment_offsets.begin<size_type>();
+  auto const oversized =
+    thrust::count_if(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                     cuda::counting_iterator<size_type>{0},
+                     cuda::counting_iterator<size_type>{num_segments},
+                     segment_exceeds_size{d_offsets, STRINGS_GRAD_WARP_CAP});
+  return oversized == 0;
+}
+
+[[nodiscard]] std::unique_ptr<column> fast_segmented_sorted_order_strings_grad(
+  column_view const& input,
+  column_view const& segment_offsets,
+  sort_polarity polarity,
+  rmm::cuda_stream_view stream,
+  rmm::device_async_resource_ref mr)
+{
+  auto const num_elements = input.size();
+  auto const num_segments = segment_offsets.size() - 1;
+  auto const d_input      = column_device_view::create(input, stream);
+  auto const has_nulls    = input.has_nulls();
+  auto const d_offsets    = segment_offsets.begin<size_type>();
+
+  auto sorted_indices = cudf::make_numeric_column(
+    data_type{type_to_id<size_type>()}, num_elements, mask_state::UNALLOCATED, stream, mr);
+  auto* const d_out = sorted_indices->mutable_view().begin<size_type>();
+
+  // The band kernel walks an explicit segment list; this path sorts every segment, so the list is
+  // the identity sequence shared by every band.
+  rmm::device_uvector<size_type> seg_list(num_segments, stream);
+  thrust::sequence(rmm::exec_policy_nosync(stream, cudf::get_current_device_resource_ref()),
+                   seg_list.begin(),
+                   seg_list.end(),
+                   0);
+
+  // The bottom bands take the 8-byte comparator key, the upper bands the 16-byte prekey; both
+  // triples carry the requested `polarity`. The pad class stays fixed at `tier_pad`, which ranks
+  // strictly above either element class regardless of polarity.
+  auto const cmp_build = strings_grad_cmp_key_builder{*d_input, has_nulls, polarity};
+  auto const cmp_less  = strings_grad_cmp_less{*d_input, polarity};
+  auto const cmp_pad   = strings_grad_cmp_key{0, static_cast<cuda::std::uint32_t>(tier_pad)};
+  auto const pre_build = strings_grad_prekey_builder{*d_input, has_nulls, polarity};
+  auto const pre_less  = strings_grad_prekey_less{*d_input, polarity};
+  auto const pre_pad   = strings_grad_prekey{0, 0, static_cast<cuda::std::uint32_t>(tier_pad)};
+
+  // (0,8] sorts at one item per lane in an 8-slot tile; (8,16] at two items; then W16/W32 for the
+  // upper bands. Each band self-filters to its size slice over the shared segment list.
+  launch_strings_grad_band<8, 1>(
+    cmp_build, cmp_less, cmp_pad, d_offsets, seg_list.data(), num_segments, 0, 8, d_out, stream);
+  launch_strings_grad_band<8, 2>(
+    cmp_build, cmp_less, cmp_pad, d_offsets, seg_list.data(), num_segments, 8, 16, d_out, stream);
+  launch_strings_grad_band<16, 2>(
+    pre_build, pre_less, pre_pad, d_offsets, seg_list.data(), num_segments, 16, 32, d_out, stream);
+  launch_strings_grad_band<32, 2>(pre_build,
+                                  pre_less,
+                                  pre_pad,
+                                  d_offsets,
+                                  seg_list.data(),
+                                  num_segments,
+                                  32,
+                                  STRINGS_GRAD_WARP_CAP,
+                                  d_out,
+                                  stream);
   return sorted_indices;
 }
 

--- a/cpp/tests/lists/sort_lists_tests.cpp
+++ b/cpp/tests/lists/sort_lists_tests.cpp
@@ -13,6 +13,7 @@
 #include <cudf/lists/sorting.hpp>
 
 #include <algorithm>
+#include <array>
 #include <limits>
 #include <random>
 #include <string>
@@ -393,6 +394,45 @@ void expect_both_sort_paths_equivalent(cudf::lists_column_view const& input,
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(sorted->view(), expected);
   auto const stable_sorted = cudf::lists::stable_sort_lists(input, column_order, null_precedence);
   CUDF_TEST_EXPECT_COLUMNS_EQUIVALENT(stable_sorted->view(), expected);
+}
+
+// Host oracle for one list row under an explicit (order, null_order): sorts the non-null values
+// (descending reverses) and rebuilds the row with its nulls on the side the combo produces. cudf's
+// null_order is comparator-level and a DESCENDING sort swaps the comparison operands, inverting
+// null placement too, so nulls land first exactly when (BEFORE) != (DESCENDING) -- the placement
+// the pre-existing comparison-path combo tests pin, and which the paired stable_sort_lists
+// assertion re-verifies at run time. Null slots carry a zeroed payload; their bytes are never
+// compared.
+template <typename T>
+std::pair<std::vector<T>, std::vector<bool>> host_sorted_row(std::vector<T> const& vals,
+                                                             std::vector<bool> const& valids,
+                                                             cudf::order column_order,
+                                                             cudf::null_order null_precedence)
+{
+  std::vector<T> nn;
+  for (std::size_t i = 0; i < vals.size(); ++i) {
+    if (valids[i]) { nn.push_back(vals[i]); }
+  }
+  std::sort(nn.begin(), nn.end());
+  if (column_order == cudf::order::DESCENDING) { std::reverse(nn.begin(), nn.end()); }
+  auto const num_nulls = vals.size() - nn.size();
+  auto const nulls_first =
+    (null_precedence == cudf::null_order::BEFORE) != (column_order == cudf::order::DESCENDING);
+  std::vector<T> out;
+  std::vector<bool> out_valids;
+  auto const push_nulls = [&] {
+    for (std::size_t k = 0; k < num_nulls; ++k) {
+      out.push_back(T{});
+      out_valids.push_back(false);
+    }
+  };
+  if (nulls_first) { push_nulls(); }
+  for (auto const& v : nn) {
+    out.push_back(v);
+    out_valids.push_back(true);
+  }
+  if (not nulls_first) { push_nulls(); }
+  return {std::move(out), std::move(out_valids)};
 }
 
 // Wraps a leaf column as a single-row LIST (every element in one list row) -- the shape the
@@ -931,6 +971,243 @@ TEST_F(SortListsString, PrefixTrueHeapsortRun)
   auto const input    = make_single_row_list(shuffled);
   auto const expected = make_single_row_list(sorted);
   expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view());
+}
+
+namespace {
+// Builds a LIST<STRING> column from per-row (string, validity) data: flattens the rows into one
+// leaf strings column carrying the validity plus a matching offsets column. Embedded NUL bytes ride
+// through unchanged (a string is a byte sequence), so callers pass explicit-length `std::string`s.
+std::unique_ptr<cudf::column> make_string_lists(std::vector<std::vector<std::string>> const& rows,
+                                                std::vector<std::vector<bool>> const& valids)
+{
+  std::vector<std::string> flat;
+  std::vector<bool> flat_v;
+  std::vector<cudf::size_type> offsets{0};
+  for (std::size_t r = 0; r < rows.size(); ++r) {
+    flat.insert(flat.end(), rows[r].begin(), rows[r].end());
+    flat_v.insert(flat_v.end(), valids[r].begin(), valids[r].end());
+    offsets.push_back(static_cast<cudf::size_type>(flat.size()));
+  }
+  cudf::test::strings_column_wrapper leaf(flat.begin(), flat.end(), flat_v.begin());
+  cudf::test::fixed_width_column_wrapper<cudf::size_type> off(offsets.begin(), offsets.end());
+  return cudf::make_lists_column(
+    static_cast<cudf::size_type>(rows.size()), off.release(), leaf.release(), 0, {});
+}
+
+// Drives one set of LIST<STRING> rows through all four (order, null_order) combos, checking the
+// fast path and the comparison path against a per-row host oracle (`host_sorted_row`, unsigned-byte
+// order with `std::string`'s length tie-break -- the same order cudf uses). Each combo folds a
+// distinct polarity into the keys, so a wrong descending byte complement, exhausted-run side, or
+// null side shows up as a mismatch here.
+void expect_string_polarity_matrix(std::vector<std::vector<std::string>> const& rows,
+                                   std::vector<std::vector<bool>> const& valids)
+{
+  constexpr std::array<std::pair<cudf::order, cudf::null_order>, 4> combos{
+    {{cudf::order::ASCENDING, cudf::null_order::AFTER},
+     {cudf::order::DESCENDING, cudf::null_order::AFTER},
+     {cudf::order::ASCENDING, cudf::null_order::BEFORE},
+     {cudf::order::DESCENDING, cudf::null_order::BEFORE}}};
+  auto const input = make_string_lists(rows, valids);
+  for (auto const& [ord, np] : combos) {
+    std::vector<std::vector<std::string>> ex_rows(rows.size());
+    std::vector<std::vector<bool>> ex_valids(rows.size());
+    for (std::size_t r = 0; r < rows.size(); ++r) {
+      auto sorted_row = host_sorted_row(rows[r], valids[r], ord, np);
+      ex_rows[r]      = std::move(sorted_row.first);
+      ex_valids[r]    = std::move(sorted_row.second);
+    }
+    auto const expected = make_string_lists(ex_rows, ex_valids);
+    expect_both_sort_paths_match(cudf::lists_column_view{input->view()}, expected->view(), ord, np);
+  }
+}
+}  // namespace
+
+// ===== graduated-warp string path: per-band polarity coverage (segments within the 64-element cap)
+// The graduated in-warp sort is the default string fast path once every segment fits the largest
+// warp tile, so these drive its bands -- (0,8] one item per lane, (8,16] W8, W16, W32 -- through
+// the full (order, null_order) matrix against the comparison-path oracle. Rows are shuffled so the
+// sort must actively reorder; a bug that left the input order (e.g. a comparator collapsing valid
+// pairs to "equal") shows up as a mismatch.
+
+// Segment sizes pinned at and across every graduated band boundary -- 1..16 (W8), 17..32 (W16),
+// 33..64 (W32) -- including 8/9 (the (0,8]/(8,16] split edge), 15/16/17, 31/32/33, 63/64 and an
+// empty row, all in one column so the bands run side by side. The 16/32/64 rows fill their W*IPT
+// tiles exactly (zero pads), as does the 8 row for the one-item-per-lane band. All-distinct
+// strings, no nulls, so the descending combos exercise the packed-window byte complement across
+// every band.
+TEST_F(SortListsString, GradPolarityMatrixBandBoundarySizes)
+{
+  std::vector<cudf::size_type> const sizes{1, 2, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 0};
+  std::mt19937 rng{0xBEEF};
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (auto const n : sizes) {
+    std::vector<std::string> row(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      // Distinct within a row: 97 is coprime to 1000, so the numeric part never repeats for i < 64.
+      row[i] = "k" + std::to_string(i * 97 % 1000) + static_cast<char>('a' + i % 26);
+    }
+    std::shuffle(row.begin(), row.end(), rng);
+    valids.emplace_back(row.size(), true);
+    rows.push_back(std::move(row));
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Null handling in every band, and the direct regression for the class-bit polarity resolution: the
+// two nulls-first combos (ASC/BEFORE and DESC/AFTER on this null-bearing column) put the valid
+// class at ordinal 1, so a comparator hardcoding the valid class to 0 would collapse every
+// valid-vs-valid pair to "equal" and leave the shuffled input order -- caught here as a mismatch.
+// Row 0 (W8 band) mixes 10 valids (one duplicate) with 2 nulls; row 1's 17 elements have only 2
+// valid (its W16 tile holds 15 nulls then 15 pad slots, the pad-boundary stressor a pad class
+// failing to rank above tier_null would break); row 5 is all null; rows of 5 and 8 put nulls in the
+// (0,8] one-item-per-lane band.
+TEST_F(SortListsString, GradPolarityMatrixNullsAcrossBands)
+{
+  std::vector<cudf::size_type> const sizes{12, 17, 20, 40, 64, 16, 5, 8};
+  std::mt19937 rng{0xD00D};
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (std::size_t r = 0; r < sizes.size(); ++r) {
+    auto const n = sizes[r];
+    std::vector<std::pair<std::string, bool>> cells(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      // Row 1: only elements 3 and 11 valid (2 valid / 15 null). Row 5: all null. Others: every
+      // (i % 5 == 2) element is null.
+      bool const v = (r == 1) ? (i == 3 || i == 11) : (r == 5 ? false : (i % 5 != 2));
+      cells[i]     = {"v" + std::to_string(i * 97 % 1000), v};
+    }
+    if (n > 1 && cells[0].second && cells[1].second) {
+      cells[1].first = cells[0].first;  // A duplicate among the valids.
+    }
+    std::shuffle(cells.begin(), cells.end(), rng);  // Interleave nulls; don't pre-group them.
+    std::vector<std::string> row(n);
+    std::vector<bool> valid(n);
+    for (cudf::size_type i = 0; i < n; ++i) {
+      row[i]   = cells[i].first;
+      valid[i] = cells[i].second;
+    }
+    rows.push_back(std::move(row));
+    valids.push_back(std::move(valid));
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Ties and zero-extension families across bands: exact duplicates, strings colliding on the packed
+// eight-byte window through its zero-fill (`S` vs `S + "\0"`, separable only by the length
+// tie-break
+// -- the exhausted-window case whose side the descending complement flips), embedded NUL bytes
+// ordering before printable bytes, and eight-byte shared prefixes forcing every pair onto the
+// suffix fallback. Row 0 is a W8-band family, row 1 a W16-band shared prefix, row 2 a W32-band
+// shared prefix, row 3 pure duplicates.
+TEST_F(SortListsString, GradPolarityMatrixTiesAndZeroExtension)
+{
+  using namespace std::string_literals;
+  std::mt19937 rng{0xACE5};
+  std::vector<std::string> row0{""s, "a"s, "ab"s, "ab"s, "ab\0"s, "ab\0c"s, "abc"s, "abcd"s, "b"s};
+  std::vector<std::string> row1;
+  for (int i = 0; i < 16; ++i) {
+    row1.push_back("PPPPPPPP" + std::to_string(i));
+  }
+  row1.push_back("PPPPPPPP"s);
+  row1.push_back("PPPPPPPP\0"s);
+  row1.push_back("PPPPPPPP3"s);  // duplicate
+  row1.push_back("PPPPPPPP7"s);  // duplicate
+  std::vector<std::string> row2;
+  for (int i = 0; i < 38; ++i) {
+    row2.push_back("SAMEPREF" + std::string(1, static_cast<char>('0' + (i % 10))) +
+                   std::to_string(i));
+  }
+  row2.push_back("SAMEPREF"s);
+  row2.push_back("SAMEPREF\0"s);
+  std::vector<std::string> row3(10, "dup"s);
+
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (auto* row : {&row0, &row1, &row2, &row3}) {
+    std::shuffle(row->begin(), row->end(), rng);
+    valids.emplace_back(row->size(), true);
+    rows.push_back(*row);
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// UTF-8 multibyte ordering: raw unsigned-byte order across the two-, three-, and four-byte lead
+// classes in a W8-band row, and a W32-band row where every string shares a two-byte multibyte
+// prefix so the prekey ties past the lead bytes. Polarity is orthogonal to encoding; the descending
+// pass is a cheap byte-complement sanity check.
+TEST_F(SortListsString, GradPolarityMatrixUtf8Multibyte)
+{
+  std::mt19937 rng{0xFACE};
+  std::vector<std::string> row0{
+    "\xE2\x82\xAC\x75\x72\x6F", "zoo", "\xF0\x9F\x98\x80", "\xC3\xA9\x70\xC3\xA9\x65", "apple"};
+  std::vector<std::string> row1;
+  for (int i = 0; i < 36; ++i) {
+    row1.push_back("\xC3\xA9" + std::to_string(i * 97 % 1000));
+  }
+  std::vector<std::vector<std::string>> rows;
+  std::vector<std::vector<bool>> valids;
+  for (auto* row : {&row0, &row1}) {
+    std::shuffle(row->begin(), row->end(), rng);
+    valids.emplace_back(row->size(), true);
+    rows.push_back(*row);
+  }
+  expect_string_polarity_matrix(rows, valids);
+}
+
+// Nonzero column offset under every combo: slicing off row 0 gives the surviving rows' leaf strings
+// a genuine nonzero offset, which the graduated key builders and comparators must honor through
+// `column_device_view::element` / `is_null`. The null slot carries "x" (never compared); the paired
+// stable_sort_lists assertion re-verifies each hand-built expectation against the comparison path.
+TEST_F(SortListsString, GradSlicedWithNulls)
+{
+  using StrLCW = cudf::test::lists_column_wrapper<cudf::string_view>;
+  StrLCW l{StrLCW{"zz", "aa"},
+           StrLCW{{"banana", "apple", "x", "cherry"}, null_at(2)},  // element 2 ("x") is null
+           StrLCW{"b", "a"},
+           StrLCW{"x"}};
+  auto const sliced = cudf::slice(l, {1, 4})[0];  // drops row 0 -> nonzero child offset
+  {                                               // ASC / AFTER: values ascending, null last
+    StrLCW expected{
+      StrLCW{{"apple", "banana", "cherry", "x"}, null_at(3)}, StrLCW{"a", "b"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(cudf::lists_column_view{sliced}, expected);
+  }
+  {  // ASC / BEFORE: null first, then values ascending
+    StrLCW expected{
+      StrLCW{{"x", "apple", "banana", "cherry"}, null_at(0)}, StrLCW{"a", "b"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::ASCENDING, cudf::null_order::BEFORE);
+  }
+  {  // DESC / AFTER: the comparator swap places the null first, then values descending
+    StrLCW expected{
+      StrLCW{{"x", "cherry", "banana", "apple"}, null_at(0)}, StrLCW{"b", "a"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::DESCENDING, cudf::null_order::AFTER);
+  }
+  {  // DESC / BEFORE: values descending, then the null last
+    StrLCW expected{
+      StrLCW{{"cherry", "banana", "apple", "x"}, null_at(3)}, StrLCW{"b", "a"}, StrLCW{"x"}};
+    expect_both_sort_paths_match(
+      cudf::lists_column_view{sliced}, expected, cudf::order::DESCENDING, cudf::null_order::BEFORE);
+  }
+}
+
+// The admission gate's negative side under every combo: one 65-element segment exceeds the
+// 64-element warp cap, disqualifying the whole column, so the graduated path is rejected and the
+// prefix path produces the result. The only observable contract is an unchanged, correct order
+// under each polarity -- which the matrix checks against the comparison-path oracle.
+TEST_F(SortListsString, GradOversizedSegmentFallsThrough)
+{
+  std::mt19937 rng{0xF00D};
+  std::vector<std::string> big(65);
+  for (int i = 0; i < 65; ++i) {
+    big[i] = "q" + std::to_string(i * 97 % 1000);
+  }
+  std::shuffle(big.begin(), big.end(), rng);
+  std::vector<std::vector<std::string>> const rows{big, {"b", "a", "c"}};
+  std::vector<std::vector<bool>> const valids{std::vector<bool>(big.size(), true),
+                                              {true, true, true}};
+  expect_string_polarity_matrix(rows, valids);
 }
 
 // Sign-flip correctness at the signed-integer boundaries: INT_MIN must sort first and INT_MAX last


### PR DESCRIPTION
The prefix-radix string path runs a full multi-pass radix machine even when every segment is tiny, where its global passes cost more than the sort saves. When every segment fits the largest warp tile (`STRINGS_GRAD_WARP_CAP` = 64, the W32 x 2 register tile), a per-segment in-warp `cub::WarpMergeSort` beats that machine. Add `fast_segmented_sorted_order_strings_grad`: it sorts each segment inside a virtual warp whose width graduates with the segment-size band (W8 for sizes up to 16, W16 for 17 to 32, W32 for 33 to 64), so a tiny segment never ties up a full warp. The key style is mixed per band -- an 8-byte comparator key drives the bottom bands, where a wider prekey would spend its merge-exchange volume on mostly-pad tiles, while the packed prefix prekey drives W16 and W32, where its window amortizes; the smallest slice sorts one item per lane to halve pad traffic.

`strings_grad_all_segments_fit` probes the segment offsets and routes the ascending nulls-after fast path to the graduated engine only when no segment exceeds the cap; any oversized segment falls through to `fast_segmented_sorted_order_strings_prefix`. The requested order and null order ride the same `sort_polarity` the prefix path uses, so validity folds into the key ordering with no separate null pass. The scalar gate clauses precede the synchronizing coverage and size probes, so the probe cost is paid only on the ascending nulls-after shape it serves.

Versus the prefix-radix path it stacks on, the numbers benchmark certifies 24 impacted string cells -- ascending, nulls-after, small segments -- all faster, geomean 1.88x with no certified regression; the remaining 96 cells stay within benchmark noise (worst 4.66 percent slower). Tests pin the graduated path against the stable comparison sort across the warp-width bands and the cap boundary.

---

**Stacked series — part 6/7, decomposing rapidsai/cudf#23101 into reviewable steps.** Stacked on #79 (base branch `improve-list-sort-05-strings-prefix`).

**compute-sanitizer:** memcheck + racecheck (`--rmm-mode=cuda`) over the `LIST<STRING>` sort tests — **0 errors, 0 hazards**.
